### PR TITLE
Add Hide Table Columns for categories and images

### DIFF
--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -29,6 +29,7 @@ $wa = $this->document->getWebAssetManager();
 $wa->useStyle('com_joomgallery.admin')
    ->useScript('com_joomgallery.admin')
    ->useScript('com_joomgallery.catBtns')
+   ->useScript('table.columns')
    ->useScript('multiselect');
 
 $user      = Factory::getUser();

--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -69,7 +69,7 @@ if($saveOrder && !empty($this->items))
                   <?php echo HTMLHelper::_('searchtools.sort', '', 'a.lft', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-sort'); ?>
                 </th>
                 <th scope="col" class="w-1 text-center">
-                  <?php // Spaceholder for thumbnail image ?>
+                  <?php echo Text::_('COM_JOOMGALLERY_IMAGE') ?>
                 </th>
                 <th scope="col" class="w-1 text-center">
                   <?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>

--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -46,17 +46,20 @@ if($saveOrder && !empty($this->items))
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>" method="post" name="adminForm" id="adminForm">
-  <div class="row">
-    <div class="col-md-12">
-      <div id="j-main-container" class="j-main-container">
-        <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-          <table class="table" id="categoryList">
+<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>" method="post"
+	  name="adminForm" id="adminForm">
+	<div class="row">
+		<div class="col-md-12">
+			<div id="j-main-container" class="j-main-container">
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<div class="clearfix"></div>
+        <div class="table-responsive">
+          <table class="table table-striped" id="categoryList">
             <caption class="visually-hidden">
-              <?php echo Text::_('COM_JOOMGALLERY_CATEGORY_TABLE_CAPTION'); ?>,
-              <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-              <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
-            </caption>
+							<?php echo Text::_('COM_JOOMGALLERY_CATEGORY_TABLE_CAPTION'); ?>,
+							<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+							<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+						</caption>
             <thead>
               <tr>
                 <td class="w-1 text-center">
@@ -248,6 +251,7 @@ if($saveOrder && !empty($this->items))
               <?php endforeach; ?>
             </tbody>
           </table>
+        </div>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
         <input type="hidden" id="del_force" name="del_force" value="0"/>

--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -46,20 +46,17 @@ if($saveOrder && !empty($this->items))
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>" method="post"
-	  name="adminForm" id="adminForm">
-	<div class="row">
-		<div class="col-md-12">
-			<div id="j-main-container" class="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-				<div class="clearfix"></div>
-        <div class="table-responsive">
-          <table class="table table-striped" id="categoryList">
+<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>" method="post" name="adminForm" id="adminForm">
+  <div class="row">
+    <div class="col-md-12">
+      <div id="j-main-container" class="j-main-container">
+        <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+          <table class="table" id="categoryList">
             <caption class="visually-hidden">
-							<?php echo Text::_('COM_JOOMGALLERY_CATEGORY_TABLE_CAPTION'); ?>,
-							<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-							<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
-						</caption>
+              <?php echo Text::_('COM_JOOMGALLERY_CATEGORY_TABLE_CAPTION'); ?>,
+              <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+              <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+            </caption>
             <thead>
               <tr>
                 <td class="w-1 text-center">
@@ -251,7 +248,6 @@ if($saveOrder && !empty($this->items))
               <?php endforeach; ?>
             </tbody>
           </table>
-        </div>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
         <input type="hidden" id="del_force" name="del_force" value="0"/>

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -47,12 +47,15 @@ if($saveOrder && !empty($this->items))
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>" method="post" name="adminForm" id="adminForm">
-  <div class="row">
-    <div class="col-md-12">
-      <div id="j-main-container" class="j-main-container">
-        <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-          <table class="table itemList" id="imageList">
+<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>" method="post"
+	  name="adminForm" id="adminForm">
+	<div class="row">
+		<div class="col-md-12">
+			<div id="j-main-container" class="j-main-container">
+			<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<div class="clearfix"></div>
+        <div class="table-responsive">
+          <table class="table table-striped" id="imageList">
             <caption class="visually-hidden">
               <?php echo Text::_('COM_JOOMGALLERY_IMAGES_TABLE_CAPTION'); ?>,
               <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
@@ -294,6 +297,7 @@ if($saveOrder && !empty($this->items))
             <?php endforeach; ?>
             </tbody>
           </table>
+        </div>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
 				<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -30,6 +30,7 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/src/Helper/');
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useStyle('com_joomgallery.admin')
    ->useScript('com_joomgallery.admin')
+   ->useScript('table.columns')
    ->useScript('multiselect');
 
 $user      = Factory::getUser();

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -78,7 +78,7 @@ if($saveOrder && !empty($this->items))
                   <?php echo HTMLHelper::_('searchtools.sort',  'JPUBLISHED', 'a.published', $listDirn, $listOrder); ?>
                 </th>
                 <th scope="col" class="w-1 text-center">
-                  <?php // Spaceholder for thumbnail image ?>
+                  <?php echo Text::_('COM_JOOMGALLERY_IMAGE') ?>
                 </th>
                 <th scope="col" style="min-width:180px">
                   <?php echo HTMLHelper::_('searchtools.sort',  'JGLOBAL_TITLE', 'a.imgtitle', $listDirn, $listOrder); ?>

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -47,15 +47,12 @@ if($saveOrder && !empty($this->items))
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>" method="post"
-	  name="adminForm" id="adminForm">
-	<div class="row">
-		<div class="col-md-12">
-			<div id="j-main-container" class="j-main-container">
-			<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-				<div class="clearfix"></div>
-        <div class="table-responsive">
-          <table class="table table-striped" id="imageList">
+<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>" method="post" name="adminForm" id="adminForm">
+  <div class="row">
+    <div class="col-md-12">
+      <div id="j-main-container" class="j-main-container">
+        <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+          <table class="table itemList" id="imageList">
             <caption class="visually-hidden">
               <?php echo Text::_('COM_JOOMGALLERY_IMAGES_TABLE_CAPTION'); ?>,
               <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
@@ -297,7 +294,6 @@ if($saveOrder && !empty($this->items))
             <?php endforeach; ?>
             </tbody>
           </table>
-        </div>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
 				<?php echo HTMLHelper::_('form.token'); ?>


### PR DESCRIPTION
Since joomla 4.2 there is a nice feature to hide any column in the table views: https://github.com/joomla/joomla-cms/pull/36591

@szepty-ziemi had already suggested the implementation at the last online meeting.
Surprisingly, the implementation in the JoomGallery was very simple.
Used for categories and images view because in tags and configuration view there are only a few columns.