### PR TITLE
Reorganise toolbar buttons

### DIFF
--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -71,33 +71,74 @@ class HtmlView extends JoomGalleryView
 		parent::display($tpl);
 	}
 
-	/**
-	 * Add the page title and toolbar.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	protected function addToolbar()
-	{
-		$state = $this->get('State');
-		$canDo = JoomHelper::getActions('category');
+  /**
+   * Add the page title and toolbar.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+   */
+  protected function addToolbar()
+  {
+    $state = $this->get('State');
+    $canDo = JoomHelper::getActions('category');
 
-		ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CATEGORY_MANAGER'), "folder-open");
+    ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CATEGORY_MANAGER'), "folder-open");
 
-		$toolbar = Toolbar::getInstance('toolbar');
+    $toolbar = Toolbar::getInstance('toolbar');
 
-		// Check if the form exists before showing the add/edit buttons
-		$formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Categories';
+    // Check if the form exists before showing the add/edit buttons
+    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Categories';
 
-		if(file_exists($formPath))
-		{
-			if($canDo->get('core.create'))
-			{
-				$toolbar->addNew('category.add');
-			}
-		}
+    // New button
+    if(file_exists($formPath))
+    {
+      if($canDo->get('core.create'))
+      {
+        $toolbar->addNew('category.add');
+      }
+    }
 
+    if($canDo->get('core.edit.state')  || count($this->transitions))
+    {
+      // Batch button
+      if($canDo->get('core.edit'))
+      {
+        $batch_dropdown = $toolbar->dropdownButton('batch-group')
+          ->text('JTOOLBAR_BATCH')
+          ->toggleSplit(false)
+          ->icon('fas fa-ellipsis-h')
+          ->buttonClass('btn btn-action')
+          ->listCheck(true);
+      
+        $batch_childBar = $batch_dropdown->getChildToolbar();
+
+        // Duplicate button inside batch dropdown
+        $batch_childBar->standardButton('duplicate')
+          ->text('JTOOLBAR_DUPLICATE')
+          ->icon('fas fa-copy')
+          ->task('categories.duplicate')
+          ->listCheck(true);
+      }
+
+      // State button
+      $dropdown = $toolbar->dropdownButton('status-group')
+        ->text('JSTATUS')
+        ->toggleSplit(false)
+        ->icon('fas fa-ellipsis-h')
+        ->buttonClass('btn btn-action')
+        ->listCheck(true);
+
+      $status_childBar = $dropdown->getChildToolbar();
+
+      if(isset($this->items[0]->published))
+      {
+        $status_childBar->publish('categories.publish')->listCheck(true);
+        $status_childBar->unpublish('categories.unpublish')->listCheck(true);
+      }
+    }
+
+    // Delete button
     if($canDo->get('core.delete'))
     {
       // Get infos for confirmation message
@@ -110,78 +151,43 @@ class HtmlView extends JoomGalleryView
       }
 
       $toolbar->delete('categories.delete')
-				->text('JTOOLBAR_DELETE')
-				->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_CATEGORIES'))
-				->listCheck(true);
+        ->text('JTOOLBAR_DELETE')
+        ->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_CATEGORIES'))
+        ->listCheck(true);
 
       // Add button javascript
       $this->deleteBtnJS  = 'var counts = '. \json_encode($counts).';';
     }
 
-    if($canDo->get('core.edit.state')  || count($this->transitions))
-		{
-			$status_dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_PUBLISH')
-				->toggleSplit(false)
-				->icon('fas fa-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
-
-			$status_childBar = $status_dropdown->getChildToolbar();
-
-			if(isset($this->items[0]->published))
-			{
-				$status_childBar->publish('categories.publish')->listCheck(true);
-				$status_childBar->unpublish('categories.unpublish')->listCheck(true);
-			}
-		}
-
-    if($canDo->get('core.edit'))
-		{
-      $batch_dropdown = $toolbar->dropdownButton('batch-group')
-        ->text('JTOOLBAR_BATCH')
-        ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
-        ->buttonClass('btn btn-action')
-        ->listCheck(true);
-      
-      $batch_childBar = $batch_dropdown->getChildToolbar();
-
-      // Duplicate button inside batch dropdown
-      $batch_childBar->standardButton('duplicate')
-				->text('JTOOLBAR_DUPLICATE')
-				->icon('fas fa-copy')
-				->task('categories.duplicate')
-				->listCheck(true);
+    if($canDo->get('core.admin'))
+    {
+      $toolbar->standardButton('refresh')
+        ->text('JTOOLBAR_REBUILD')
+        ->task('categories.rebuild');
     }
 
-		if($canDo->get('core.admin'))
-		{
-			$toolbar->standardButton('refresh')
-				->text('JTOOLBAR_REBUILD')
-				->task('categories.rebuild');
-		}
+    // Show trash and delete for components that uses the state field
+    if(isset($this->items[0]->published))
+    {
+      if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+      {
+        $toolbar->delete('categories.delete')
+          ->text('JTOOLBAR_EMPTY_TRASH')
+          ->message('JGLOBAL_CONFIRM_DELETE')
+          ->listCheck(true);
+      }
+    }
 
-		// Show trash and delete for components that uses the state field
-		if(isset($this->items[0]->published))
-		{
-			if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-			{
-				$toolbar->delete('categories.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
-		}
 
-		if($canDo->get('core.admin'))
-		{
-			$toolbar->preferences('com_joomgallery');
-		}
+    if($canDo->get('core.admin'))
+    {
+      $toolbar->preferences('com_joomgallery');
+    }
 
-		// Set sidebar action
-		Sidebar::setAction('index.php?option=com_joomgallery&view=categories');
-	}
+    // Set sidebar action
+    Sidebar::setAction('index.php?option=com_joomgallery&view=categories');
+  }
+
 
 	/**
 	 * Method to order fields

--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -107,7 +107,7 @@ class HtmlView extends JoomGalleryView
         $batch_dropdown = $toolbar->dropdownButton('batch-group')
           ->text('JTOOLBAR_BATCH')
           ->toggleSplit(false)
-          ->icon('fas fa-ellipsis-h')
+          ->icon('far fa-folder-open')
           ->buttonClass('btn btn-action')
           ->listCheck(true);
       

--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -125,7 +125,7 @@ class HtmlView extends JoomGalleryView
       $dropdown = $toolbar->dropdownButton('status-group')
         ->text('JSTATUS')
         ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
+        ->icon('far fa-check-circle')
         ->buttonClass('btn btn-action')
         ->listCheck(true);
 
@@ -178,7 +178,6 @@ class HtmlView extends JoomGalleryView
       }
     }
 
-
     if($canDo->get('core.admin'))
     {
       $toolbar->preferences('com_joomgallery');
@@ -187,7 +186,6 @@ class HtmlView extends JoomGalleryView
     // Set sidebar action
     Sidebar::setAction('index.php?option=com_joomgallery&view=categories');
   }
-
 
 	/**
 	 * Method to order fields

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -113,7 +113,7 @@ class HtmlView extends JoomGalleryView
       $dropdown = $toolbar->dropdownButton('status-group')
         ->text('JSTATUS')
         ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
+        ->icon('far fa-check-circle')
         ->buttonClass('btn btn-action')
         ->listCheck(true);
 

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -103,36 +103,36 @@ class HtmlView extends JoomGalleryView
 
       $childBar = $dropdown->getChildToolbar();
 
-      if(isset($this->items[0]->state))
-      {
-        $childBar->publish('configs.publish')->listCheck(true);
-        $childBar->unpublish('configs.unpublish')->listCheck(true);
-        $childBar->archive('configs.archive')->listCheck(true);
-      }
-      elseif(isset($this->items[0]))
-      {
-        // If this component does not use state then show a direct delete button as we can not trash
-        $toolbar->delete('configs.delete')
-        ->text('JTOOLBAR_DELETE')
-        ->message('JGLOBAL_CONFIRM_DELETE')
-        ->listCheck(true);
-      }
-
       $childBar->standardButton('duplicate')
         ->text('JTOOLBAR_DUPLICATE')
         ->icon('fas fa-copy')
         ->task('configs.duplicate')
         ->listCheck(true);
 
-      if(isset($this->items[0]->checked_out))
-      {
-        $childBar->checkin('configs.checkin')->listCheck(true);
-      }
+      // State button
+      $dropdown = $toolbar->dropdownButton('status-group')
+        ->text('JSTATUS')
+        ->toggleSplit(false)
+        ->icon('fas fa-ellipsis-h')
+        ->buttonClass('btn btn-action')
+        ->listCheck(true);
 
-      if(isset($this->items[0]->state))
+      $status_childBar = $dropdown->getChildToolbar();
+
+      if(isset($this->items[0]->published))
       {
-        $childBar->trash('configs.trash')->listCheck(true);
+        $status_childBar->publish('configs.publish')->listCheck(true);
+        $status_childBar->unpublish('configs.unpublish')->listCheck(true);
       }
+    }
+
+    // Delete button
+    if($canDo->get('core.delete'))
+    {
+      $toolbar->delete('configs.delete')
+        ->text('JTOOLBAR_DELETE')
+        ->message('COM_JOOMGALLERY_CONFIRM_DELETE_CONFIGS')
+        ->listCheck(true);
     }
 
     // Show trash and delete for components that uses the state field

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -63,96 +63,98 @@ class HtmlView extends JoomGalleryView
 		parent::display($tpl);
 	}
 
-	/**
-	 * Add the page title and toolbar.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	protected function addToolbar()
-	{
-		$state = $this->get('State');
-		$canDo = JoomHelper::getActions();
+  /**
+   * Add the page title and toolbar.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+   */
+  protected function addToolbar()
+  {
+    $state = $this->get('State');
+    $canDo = JoomHelper::getActions();
 
-		ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CONFIGURATION_MANAGER'), "sliders-h");
+    ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CONFIGURATION_MANAGER'), "sliders-h");
 
-		$toolbar = Toolbar::getInstance('toolbar');
+    $toolbar = Toolbar::getInstance('toolbar');
 
-		// Check if the form exists before showing the add/edit buttons
-		$formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Configs';
+    // Check if the form exists before showing the add/edit buttons
+    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Configs';
 
-		if(file_exists($formPath))
-		{
-			if($canDo->get('core.create'))
-			{
-				$toolbar->addNew('config.add');
-			}
-		}
+    // New button
+    if(file_exists($formPath))
+    {
+      if($canDo->get('core.create'))
+      {
+        $toolbar->addNew('config.add');
+      }
+    }
 
-		if($canDo->get('core.edit.state')  || count($this->transitions))
-		{
-			$dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_CHANGE_STATUS')
-				->toggleSplit(false)
-				->icon('fas fa-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
+    if($canDo->get('core.edit.state')  || count($this->transitions))
+    {
+      // Batch button
+      $dropdown = $toolbar->dropdownButton('status-group')
+        ->text('JTOOLBAR_BATCH')
+        ->toggleSplit(false)
+        ->icon('fas fa-ellipsis-h')
+        ->buttonClass('btn btn-action')
+        ->listCheck(true);
 
-			$childBar = $dropdown->getChildToolbar();
+      $childBar = $dropdown->getChildToolbar();
 
-			if(isset($this->items[0]->state))
-			{
-				$childBar->publish('configs.publish')->listCheck(true);
-				$childBar->unpublish('configs.unpublish')->listCheck(true);
-				$childBar->archive('configs.archive')->listCheck(true);
-			}
-			elseif(isset($this->items[0]))
-			{
-				// If this component does not use state then show a direct delete button as we can not trash
-				$toolbar->delete('configs.delete')
-				->text('JTOOLBAR_EMPTY_TRASH')
-				->message('JGLOBAL_CONFIRM_DELETE')
-				->listCheck(true);
-			}
+      if(isset($this->items[0]->state))
+      {
+        $childBar->publish('configs.publish')->listCheck(true);
+        $childBar->unpublish('configs.unpublish')->listCheck(true);
+        $childBar->archive('configs.archive')->listCheck(true);
+      }
+      elseif(isset($this->items[0]))
+      {
+        // If this component does not use state then show a direct delete button as we can not trash
+        $toolbar->delete('configs.delete')
+        ->text('JTOOLBAR_DELETE')
+        ->message('JGLOBAL_CONFIRM_DELETE')
+        ->listCheck(true);
+      }
 
-			$childBar->standardButton('duplicate')
-				->text('JTOOLBAR_DUPLICATE')
-				->icon('fas fa-copy')
-				->task('configs.duplicate')
-				->listCheck(true);
+      $childBar->standardButton('duplicate')
+        ->text('JTOOLBAR_DUPLICATE')
+        ->icon('fas fa-copy')
+        ->task('configs.duplicate')
+        ->listCheck(true);
 
-			if(isset($this->items[0]->checked_out))
-			{
-				$childBar->checkin('configs.checkin')->listCheck(true);
-			}
+      if(isset($this->items[0]->checked_out))
+      {
+        $childBar->checkin('configs.checkin')->listCheck(true);
+      }
 
-			if(isset($this->items[0]->state))
-			{
-				$childBar->trash('configs.trash')->listCheck(true);
-			}
-		}
+      if(isset($this->items[0]->state))
+      {
+        $childBar->trash('configs.trash')->listCheck(true);
+      }
+    }
 
-		// Show trash and delete for components that uses the state field
-		if(isset($this->items[0]->state))
-		{
-			if($this->state->get('filter.state') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-			{
-				$toolbar->delete('configs.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
-		}
+    // Show trash and delete for components that uses the state field
+    if(isset($this->items[0]->state))
+    {
+      if($this->state->get('filter.state') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+      {
+        $toolbar->delete('configs.delete')
+          ->text('JTOOLBAR_EMPTY_TRASH')
+          ->message('JGLOBAL_CONFIRM_DELETE')
+          ->listCheck(true);
+      }
+    }
 
-		if($canDo->get('core.admin'))
-		{
-			$toolbar->preferences('com_joomgallery');
-		}
+    if($canDo->get('core.admin'))
+    {
+      $toolbar->preferences('com_joomgallery');
+    }
 
-		// Set sidebar action
-		Sidebar::setAction('index.php?option=com_joomgallery&view=configs');
-	}
+    // Set sidebar action
+    Sidebar::setAction('index.php?option=com_joomgallery&view=configs');
+  }
 
 	/**
 	 * Method to order fields

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -97,7 +97,7 @@ class HtmlView extends JoomGalleryView
       $dropdown = $toolbar->dropdownButton('status-group')
         ->text('JTOOLBAR_BATCH')
         ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
+        ->icon('fas fa-sliders-h')
         ->buttonClass('btn btn-action')
         ->listCheck(true);
 

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -68,58 +68,37 @@ class HtmlView extends JoomGalleryView
 		parent::display($tpl);
 	}
 
-	/**
-	 * Add the page title and toolbar.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	protected function addToolbar()
-	{
-		$state = $this->get('State');
-		$canDo = JoomHelper::getActions('image');
+  /**
+   * Add the page title and toolbar.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+   */
+  protected function addToolbar()
+  {
+    $state = $this->get('State');
+    $canDo = JoomHelper::getActions('image');
 
-		ToolbarHelper::title(Text::_('COM_JOOMGALLERY_IMAGE_MANAGER'), "image");
+    ToolbarHelper::title(Text::_('COM_JOOMGALLERY_IMAGE_MANAGER'), "image");
 
-		$toolbar = Toolbar::getInstance('toolbar');
+    $toolbar = Toolbar::getInstance('toolbar');
 
-		// Check if the form exists before showing the add/edit buttons
-		$formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Images';
+    // Check if the form exists before showing the add/edit buttons
+    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Images';
 
-		if(file_exists($formPath))
-		{
-			if($canDo->get('core.create'))
-			{
-				$toolbar->addNew('image.add');
-			}
-		}
-
-    if($canDo->get('core.delete'))
+    // New button
+    if(file_exists($formPath))
     {
-      $toolbar->delete('images.delete')
-        ->text('JTOOLBAR_DELETE')
-        ->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_IMAGES'))
-        ->listCheck(true);
+      if($canDo->get('core.create'))
+      {
+        $toolbar->addNew('image.add');
+      }
     }
 
-		if($canDo->get('core.edit.state')  || count($this->transitions))
-		{
-			$dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_PUBLISH')
-				->toggleSplit(false)
-				->icon('fas fa-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
-
-			$status_childBar = $dropdown->getChildToolbar();
-
-			if(isset($this->items[0]->published))
-			{
-				$status_childBar->publish('images.publish')->listCheck(true);
-				$status_childBar->unpublish('images.unpublish')->listCheck(true);
-			}
-
+    // Batch button
+    if($canDo->get('core.edit.state') || count($this->transitions))
+    {
       if($canDo->get('core.edit'))
       {
         $batch_dropdown = $toolbar->dropdownButton('batch-group')
@@ -138,28 +117,72 @@ class HtmlView extends JoomGalleryView
           ->task('images.duplicate')
           ->listCheck(true);
       }
-		}
 
-		// Show trash and delete for components that uses the state field
-		if(isset($this->items[0]->published))
-		{
-			if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-			{
-				$toolbar->delete('categories.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
-		}
+      // Image manipulation button
+      if($canDo->get('core.edit'))
+      {
+        $batch_dropdown = $toolbar->dropdownButton('batch-group')
+          ->text('Image Manipulation')
+          ->toggleSplit(false)
+          ->icon('fas fa-ellipsis-h')
+          ->buttonClass('btn btn-action')
+          ->listCheck(true);
+        
+        $batch_childBar = $batch_dropdown->getChildToolbar();
 
-		if($canDo->get('core.admin'))
-		{
-			$toolbar->preferences('com_joomgallery');
-		}
+        // Recreate button inside image manipulation
+        $batch_childBar->standardButton('recreate')
+          ->text('recreate - comes later')
+          ->icon('fas fa-refresh')
+          ->task('images.recreate')
+          ->listCheck(true);
+      }
+  
+      // State button
+      $dropdown = $toolbar->dropdownButton('status-group')
+        ->text('JSTATUS')
+        ->toggleSplit(false)
+        ->icon('fas fa-ellipsis-h')
+        ->buttonClass('btn btn-action')
+        ->listCheck(true);
 
-		// Set sidebar action
-		Sidebar::setAction('index.php?option=com_joomgallery&view=images');
-	}
+      $status_childBar = $dropdown->getChildToolbar();
+
+      if(isset($this->items[0]->published))
+      {
+        $status_childBar->publish('images.publish')->listCheck(true);
+        $status_childBar->unpublish('images.unpublish')->listCheck(true);
+      }
+    }
+
+    if($canDo->get('core.delete'))
+    {
+      $toolbar->delete('images.delete')
+        ->text('JTOOLBAR_DELETE')
+        ->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_IMAGES'))
+        ->listCheck(true);
+    }
+
+    // Show trash and delete for components that uses the state field
+    if(isset($this->items[0]->published))
+    {
+      if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+      {
+        $toolbar->delete('images.delete')
+          ->text('JTOOLBAR_EMPTY_TRASH')
+          ->message('JGLOBAL_CONFIRM_DELETE')
+          ->listCheck(true);
+      }
+    }
+
+    if($canDo->get('core.admin'))
+    {
+      $toolbar->preferences('com_joomgallery');
+    }
+
+    // Set sidebar action
+    Sidebar::setAction('index.php?option=com_joomgallery&view=images');
+  }
 
 	/**
 	 * Method to order fields

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -124,7 +124,7 @@ class HtmlView extends JoomGalleryView
         $batch_dropdown = $toolbar->dropdownButton('batch-group')
           ->text('Image Manipulation')
           ->toggleSplit(false)
-          ->icon('fas fa-ellipsis-h')
+          ->icon('fas fa-images')
           ->buttonClass('btn btn-action')
           ->listCheck(true);
         

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -142,7 +142,7 @@ class HtmlView extends JoomGalleryView
       $dropdown = $toolbar->dropdownButton('status-group')
         ->text('JSTATUS')
         ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
+        ->icon('far fa-check-circle')
         ->buttonClass('btn btn-action')
         ->listCheck(true);
 

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -65,58 +65,37 @@ class HtmlView extends JoomGalleryView
 		parent::display($tpl);
 	} 
 
-	/**
-	 * Add the page title and toolbar.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	protected function addToolbar()
-	{
-		$state = $this->get('State');
-		$canDo = JoomHelper::getActions('tag');
+  /**
+   * Add the page title and toolbar.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+   */
+  protected function addToolbar()
+  {
+    $state = $this->get('State');
+    $canDo = JoomHelper::getActions('tag');
 
-		ToolbarHelper::title(Text::_('COM_JOOMGALLERY_TAGS_MANAGER'), "tags");
+    ToolbarHelper::title(Text::_('COM_JOOMGALLERY_TAGS_MANAGER'), "tags");
 
-		$toolbar = Toolbar::getInstance('toolbar');
+    $toolbar = Toolbar::getInstance('toolbar');
 
-		// Check if the form exists before showing the add/edit buttons
-		$formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Tags';
+    // Check if the form exists before showing the add/edit buttons
+    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Tags';
 
-		if(file_exists($formPath))
-		{
-			if($canDo->get('core.create'))
-			{
-				$toolbar->addNew('tag.add');
-			}
-		}
-
-    if($canDo->get('core.delete'))
+    // New button
+    if(file_exists($formPath))
     {
-      $toolbar->delete('tags.delete')
-        ->text('JTOOLBAR_DELETE')
-        ->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_TAGS'))
-        ->listCheck(true);
+      if($canDo->get('core.create'))
+      {
+        $toolbar->addNew('tag.add');
+      }
     }
 
     if($canDo->get('core.edit.state')  || count($this->transitions))
-		{
-			$dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_PUBLISH')
-				->toggleSplit(false)
-				->icon('fas fa-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
-
-			$status_childBar = $dropdown->getChildToolbar();
-
-			if(isset($this->items[0]->published))
-			{
-				$status_childBar->publish('tags.publish')->listCheck(true);
-				$status_childBar->unpublish('tags.unpublish')->listCheck(true);
-			}
-
+    {
+      // Batch button
       if($canDo->get('core.edit'))
       {
         $batch_dropdown = $toolbar->dropdownButton('batch-group')
@@ -135,29 +114,54 @@ class HtmlView extends JoomGalleryView
           ->task('tags.duplicate')
           ->listCheck(true);
       }
-		}
 
-		// Show trash and delete for components that uses the state field
-		if(isset($this->items[0]->published))
-		{
+      // State button
+      $dropdown = $toolbar->dropdownButton('status-group')
+        ->text('JSTATUS')
+        ->toggleSplit(false)
+        ->icon('fas fa-ellipsis-h')
+        ->buttonClass('btn btn-action')
+        ->listCheck(true);
 
-			if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-			{
-				$toolbar->delete('tags.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
-		}
+      $status_childBar = $dropdown->getChildToolbar();
 
-		if($canDo->get('core.admin'))
-		{
-			$toolbar->preferences('com_joomgallery');
-		}
+      if(isset($this->items[0]->published))
+      {
+        $status_childBar->publish('tags.publish')->listCheck(true);
+        $status_childBar->unpublish('tags.unpublish')->listCheck(true);
+      }
+    }
 
-		// Set sidebar action
-		Sidebar::setAction('index.php?option=com_joomgallery&view=tags');
-	}
+    // Delete button
+    if($canDo->get('core.delete'))
+    {
+      $toolbar->delete('tags.delete')
+        ->text('JTOOLBAR_DELETE')
+        ->message(Text::_('COM_JOOMGALLERY_CONFIRM_DELETE_TAGS'))
+        ->listCheck(true);
+    }
+
+    // Show trash and delete for components that uses the state field
+    if(isset($this->items[0]->published))
+    {
+
+      if($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+      {
+        $toolbar->delete('tags.delete')
+          ->text('JTOOLBAR_EMPTY_TRASH')
+          ->message('JGLOBAL_CONFIRM_DELETE')
+          ->listCheck(true);
+      }
+    }
+
+    if($canDo->get('core.admin'))
+    {
+      $toolbar->preferences('com_joomgallery');
+    }
+
+    // Set sidebar action
+    Sidebar::setAction('index.php?option=com_joomgallery&view=tags');
+}
 
 	/**
 	 * Method to order fields

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends JoomGalleryView
         $batch_dropdown = $toolbar->dropdownButton('batch-group')
           ->text('JTOOLBAR_BATCH')
           ->toggleSplit(false)
-          ->icon('fas fa-ellipsis-h')
+          ->icon('fas fa-tags')
           ->buttonClass('btn btn-action')
           ->listCheck(true);
         

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -119,7 +119,7 @@ class HtmlView extends JoomGalleryView
       $dropdown = $toolbar->dropdownButton('status-group')
         ->text('JSTATUS')
         ->toggleSplit(false)
-        ->icon('fas fa-ellipsis-h')
+        ->icon('far fa-check-circle')
         ->buttonClass('btn btn-action')
         ->listCheck(true);
 


### PR DESCRIPTION
Possible fix for https://github.com/JoomGalleryfriends/JG4-dev/issues/11
The toolbar buttons now have the same order and identical names in all managers:

- New
- Batch
  - Duplicate
  - ...
- State
  - Publish
  - Unpublish
- Delete


@Elfangor93 Do we need a 'state' (Publish) column for configuration(s) or can this column deleted?
