### PR TITLE
New field: JG-Category selection

### DIFF
--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -48,8 +48,8 @@
            description="JFIELD_ALIAS_DESC" />
 
     <field name="parent_id"
-           type="categoryedit"
-           default="0"
+           type="jgcategory"
+           default="1"
            label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL" />
 
     <field name="published"

--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -49,6 +49,7 @@
 
     <field name="parent_id"
            type="jgcategory"
+           children="false"
            default="1"
            label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL" />
 

--- a/administrator/com_joomgallery/forms/filter_categories.xml
+++ b/administrator/com_joomgallery/forms/filter_categories.xml
@@ -18,7 +18,7 @@
 
         <field
               name="category"
-              type="categoryedit"
+              type="jgcategorydropdown"
               label="COM_JOOMGALLERY_COMMON_ALL"
               onchange="this.form.submit();"
               show_root="false"

--- a/administrator/com_joomgallery/forms/filter_categories.xml
+++ b/administrator/com_joomgallery/forms/filter_categories.xml
@@ -25,7 +25,7 @@
               default=""
               message="COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY"
               task="filter" >
-          <option value="">JOPTION_SELECT_CATEGORY</option>
+          <option value="">COM_JOOMGALLERY_FIELDS_SELECT_PARENT</option>
         </field>
 
         <field
@@ -59,6 +59,18 @@
                label="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                hint="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                onchange="this.form.submit();" />
+
+        <field
+              name="exclude"
+              type="jgcategorydropdown"
+              label="COM_JOOMGALLERY_COMMON_ALL"
+              onchange="this.form.submit();"
+              show_root="false"
+              default=""
+              message="COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY"
+              task="filter" >
+          <option value="">COM_JOOMGALLERY_FIELDS_SELECT_EXCLUDE</option>
+        </field>
     </fields>
 
     <fields name="list">

--- a/administrator/com_joomgallery/forms/filter_categories.xml
+++ b/administrator/com_joomgallery/forms/filter_categories.xml
@@ -55,7 +55,7 @@
                onchange="this.form.submit();" />
 
         <field name="created_by"
-               type="user"
+               type="userdropdown"
                label="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                hint="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                onchange="this.form.submit();" />

--- a/administrator/com_joomgallery/forms/filter_images.xml
+++ b/administrator/com_joomgallery/forms/filter_images.xml
@@ -23,7 +23,7 @@
 
         <field
               name="category"
-              type="categoryedit"
+              type="jgcategorydropdown"
               label="COM_JOOMGALLERY_COMMON_ALL"
               onchange="this.form.submit();"
               show_root="false"

--- a/administrator/com_joomgallery/forms/image.xml
+++ b/administrator/com_joomgallery/forms/image.xml
@@ -70,7 +70,7 @@
            maxlength="255" />
 
     <field name="catid"
-           type="categoryedit"
+           type="jgcategorydropdown"
            label="JCATEGORY"
            default=""
            show_root="false"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -65,6 +65,7 @@ COM_JOOMGALLERY_WORK_IN_PROGRESS="Work in Progress"
 COM_JOOMGALLERY_REFRESH_SITE="Refresh of the site."
 COM_JOOMGALLERY_SETTINGS="Settings"
 COM_JOOMGALLERY_CHANGELOG="Changelog"
+COM_JOOMGALLERY_NO_CATEGORY="No category"
 
 ;Types
 COM_JOOMGALLERY_THUMBNAIL="Thumbnail"
@@ -201,6 +202,7 @@ COM_JOOMGALLERY_FIELDS_WATERMARK_RESIZING_DESC="Resizing watermark? If enabled t
 COM_JOOMGALLERY_FIELDS_AUTO_ORIENTATION_DESC="'Yes' to orient images automatically based on its EXIF orientation tag."
 COM_JOOMGALLERY_FIELDS_TAG_DESC="Add tags and assign them to the item."
 COM_JOOMGALLERY_FIELDS_SELECT_IMAGE="Select an image"
+COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY="Select a category"
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Inheritance method of configuration"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -203,6 +203,8 @@ COM_JOOMGALLERY_FIELDS_AUTO_ORIENTATION_DESC="'Yes' to orient images automatical
 COM_JOOMGALLERY_FIELDS_TAG_DESC="Add tags and assign them to the item."
 COM_JOOMGALLERY_FIELDS_SELECT_IMAGE="Select an image"
 COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY="Select a category"
+COM_JOOMGALLERY_FIELDS_SELECT_PARENT="- Select Parent -"
+COM_JOOMGALLERY_FIELDS_SELECT_EXCLUDE="- Select Exclude -"
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Inheritance method of configuration"

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -45,7 +45,7 @@ extract($displayData);
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
  * @var   string   $categoryName    The category name
- * @var   mixed    $categories      The filtering categories (null means no filtering)
+ * @var   mixed    $category        The filtering category (null means no filtering)
  * @var   mixed    $excluded        The categories to exclude from the list of categories
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
@@ -64,15 +64,15 @@ if($required)
 	$uri->setVar('required', 1);
 }
 
-if(!empty($categories))
-{
-	$uri->setVar('categories', base64_encode(json_encode($categories)));
-}
-
-if(!empty($excluded))
-{
-	$uri->setVar('excluded', base64_encode(json_encode($excluded)));
-}
+// Apply filter in categories list
+$uri->setVar('list[fullordering]', 'a.lft+ASC');
+$uri->setVar('list[limit]', '20');
+$uri->setVar('filter[search]', '');
+$uri->setVar('filter[published]', '*');
+$uri->setVar('filter[level]', '*');
+$uri->setVar('filter[created_by]', '');
+$uri->setVar('filter[category]', (isset($category)) ? (string) $category : '');
+$uri->setVar('filter[exclude]', (isset($excluded)) ? (string) $excluded : '');
 
 // Invalidate the input value if no image selected
 if($this->escape($categoryName) === Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY'))

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -1,0 +1,149 @@
+<?php 
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
+use Joomla\Utilities\ArrayHelper;
+use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   string   $categoryName    The category name
+ * @var   mixed    $categories      The filtering categories (null means no filtering)
+ * @var   mixed    $excluded        The categories to exclude from the list of categories
+ * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
+ * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
+ */
+$modalHTML = '';
+$uri = new Uri('index.php?option=com_joomgallery&view=categories&layout=modal&tmpl=component&required=0');
+$uri->setVar('field', $this->escape($id));
+
+if(empty($value))
+{
+  $value = 0;
+}
+
+if($required)
+{
+	$uri->setVar('required', 1);
+}
+
+if(!empty($categories))
+{
+	$uri->setVar('categories', base64_encode(json_encode($categories)));
+}
+
+if(!empty($excluded))
+{
+	$uri->setVar('excluded', base64_encode(json_encode($excluded)));
+}
+
+// Invalidate the input value if no image selected
+if($this->escape($categoryName) === Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY'))
+{
+	$categoryName = '';
+}
+
+$inputAttributes = array(
+	'type' => 'text', 'id' => $id, 'class' => 'form-control field-category-input-name', 'value' => $this->escape($categoryName)
+);
+if($class)
+{
+	$inputAttributes['class'] .= ' ' . $class;
+}
+if($size)
+{
+	$inputAttributes['size'] = (int) $size;
+}
+if($required)
+{
+	$inputAttributes['required'] = 'required';
+}
+if(!$readonly)
+{
+	$inputAttributes['placeholder'] = Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY');
+}
+
+if(!$readonly)
+{
+	$modalHTML = HTMLHelper::_(
+		'bootstrap.renderModal',
+		'categoryModal_' . $id,
+		array(
+			'url'         => $uri,
+			'title'       => Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY'),
+			'closeButton' => true,
+			'height'      => '100%',
+			'width'       => '100%',
+			'modalWidth'  => 80,
+			'bodyHeight'  => 60,
+			'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
+		)
+	);
+
+	Factory::getDocument()->getWebAssetManager()
+		->useScript('com_joomgallery.field-category');
+}
+?>
+<?php // Create a dummy text field with the category name. ?>
+<joomla-field-category class="field-category-wrapper"
+		url="<?php echo (string) $uri; ?>"
+		modal=".modal"
+		modal-width="100%"
+		modal-height="400px"
+		input=".field-category-input"
+		input-name=".field-category-input-name"
+		button-select=".button-select">
+	<div class="input-group">
+		<input <?php echo ArrayHelper::toString($inputAttributes), $dataAttribute; ?> readonly>
+		<?php if (!$readonly) : ?>
+			<button type="button" class="btn btn-primary button-select" title="<?php echo Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY'); ?>">
+				<span class="icon-folder icon-white" aria-hidden="true"></span>
+				<span class="visually-hidden"><?php echo Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY'); ?></span>
+			</button>
+		<?php endif; ?>
+	</div>
+	<?php // Create the real field, hidden, that stored the category id. ?>
+	<?php if (!$readonly) : ?>
+		<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>"
+			class="field-category-input <?php echo $class ? (string) $class : ''?>"
+			data-onchange="<?php echo $this->escape($onchange); ?>">
+		<?php echo $modalHTML; ?>
+	<?php endif; ?>
+</joomla-field-category>

--- a/administrator/com_joomgallery/src/Field/JgcategoryField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategoryField.php
@@ -119,19 +119,25 @@ class JgcategoryField extends FormField
 
 		if(is_numeric($this->value))
 		{
-      if($this->value > 0)
-      {
-        $cat = JoomHelper::getRecord('category', $this->value);
-      }
-      
-      if($this->value == 0 || !$cat)
-      {
-        $name = '';
-      }
-      else
-      {
-        $name = $cat->title;
-      }
+			if($this->value > 0)
+			{
+				$cat = JoomHelper::getRecord('category', $this->value);
+			}
+
+			// Interprete root category
+			if($this->value === 1)
+			{
+				$cat->title = Text::_('JGLOBAL_ROOT_PARENT');
+			}
+
+			if($this->value == 0 || !$cat)
+			{
+				$name = '';
+			}
+			else
+			{
+				$name = $cat->title;
+			}
 		}
 
 		// User lookup went wrong, we assign the value instead.

--- a/administrator/com_joomgallery/src/Field/JgcategoryField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategoryField.php
@@ -33,15 +33,15 @@ class JgcategoryField extends FormField
 	public $type = 'jgcategory';
 
 	/**
-	 * Filtering categories
+	 * Filtering category
 	 *
 	 * @var   array
 	 * @since 3.5
 	 */
-	protected $categories = null;
+	protected $category = null;
 
 	/**
-	 * Categories to exclude from the list of categories
+	 * Category to exclude from the list of categories
 	 *
 	 * @var   array
 	 * @since 3.5
@@ -148,7 +148,7 @@ class JgcategoryField extends FormField
 
 		$extraData = array(
 			'categoryName'  => $name,
-			'categories' => $this->getCats(),
+			'category' => $this->getCat(),
 			'excluded'   => $this->getExcluded(),
 		);
 
@@ -162,11 +162,11 @@ class JgcategoryField extends FormField
 	 *
 	 * @since   1.6
 	 */
-	protected function getCats()
+	protected function getCat()
 	{
-		if (isset($this->element['categories']))
+		if (isset($this->element['category']))
 		{
-			return explode(',', $this->element['categories']);
+			return intval($this->element['category']);
 		}
 	}
 
@@ -181,7 +181,7 @@ class JgcategoryField extends FormField
 	{
 		if (isset($this->element['exclude']))
 		{
-			return explode(',', $this->element['exclude']);
+			return intval($this->element['exclude']);
 		}
 	}
 }

--- a/administrator/com_joomgallery/src/Field/JgcategoryField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategoryField.php
@@ -1,0 +1,181 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2022  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 2 or later                          **
+*****************************************************************************************/
+
+namespace Joomgallery\Component\Joomgallery\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormField;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Field to select a JoomGallery category ID from a modal list.
+ *
+ * @since  4.0.0
+ */
+class JgcategoryField extends FormField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  1.6
+	 */
+	public $type = 'jgcategory';
+
+	/**
+	 * Filtering categories
+	 *
+	 * @var   array
+	 * @since 3.5
+	 */
+	protected $categories = null;
+
+	/**
+	 * Categories to exclude from the list of categories
+	 *
+	 * @var   array
+	 * @since 3.5
+	 */
+	protected $excluded = null;
+
+	/**
+	 * Layout to render
+	 *
+	 * @var   string
+	 * @since 3.5
+	 */
+	protected $layout = 'joomla.form.field.jgcategory';
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   3.7.0
+	 *
+	 * @see     FormField::setup()
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$return = parent::setup($element, $value, $group);
+
+		// If user can't access com_joomgallery the field should be readonly.
+		if ($return && !$this->readonly)
+		{
+			$this->readonly = !Factory::getUser()->authorise('core.manage', 'com_joomgallery');
+		}
+
+		return $return;
+	}
+
+	/**
+	 * Method to get the category field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   1.6
+	 */
+	protected function getInput()
+	{
+		if (empty($this->layout))
+		{
+			throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+		}
+
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+
+	}
+
+	/**
+	 * Get the data that is going to be passed to the layout
+	 *
+	 * @return  array
+	 *
+	 * @since   3.5
+	 */
+	public function getLayoutData()
+	{
+		// Get the basic field data
+		$data = parent::getLayoutData();
+
+		// Initialize value
+		$name = Text::_('COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY');
+
+		if(is_numeric($this->value))
+		{
+      if($this->value > 0)
+      {
+        $cat = JoomHelper::getRecord('category', $this->value);
+      }
+      
+      if($this->value == 0 || !$cat)
+      {
+        $name = '';
+      }
+      else
+      {
+        $name = $cat->title;
+      }
+		}
+
+		// User lookup went wrong, we assign the value instead.
+		if($name === null && $this->value)
+		{
+			$name = $this->value;
+		}
+
+		$extraData = array(
+			'categoryName'  => $name,
+			'categories' => $this->getCats(),
+			'excluded'   => $this->getExcluded(),
+		);
+
+		return array_merge($data, $extraData);
+	}
+
+	/**
+	 * Method to get the filtering categories (null means no filtering)
+	 *
+	 * @return  mixed  Array of filtering categories or null.
+	 *
+	 * @since   1.6
+	 */
+	protected function getCats()
+	{
+		if (isset($this->element['categories']))
+		{
+			return explode(',', $this->element['categories']);
+		}
+	}
+
+	/**
+	 * Method to get the images to exclude from the list of images
+	 *
+	 * @return  mixed  Array of images to exclude or null to to not exclude them
+	 *
+	 * @since   1.6
+	 */
+	protected function getExcluded()
+	{
+		if (isset($this->element['exclude']))
+		{
+			return explode(',', $this->element['exclude']);
+		}
+	}
+}

--- a/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
@@ -24,7 +24,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class CategoryeditField extends ListField
+class JgcategorydropdownField extends ListField
 {
 	/**
 	 * To allow creation of new categories.
@@ -48,7 +48,7 @@ class CategoryeditField extends ListField
 	 * @var    string
 	 * @since  1.6
 	 */
-	public $type = 'categoryedit';
+	public $type = 'jgcategorydropdown';
 
 	/**
 	 * Name of the layout being used to render the field

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -86,7 +86,15 @@ class CategoryModel extends JoomAdminModel
 		$app = Factory::getApplication();
 
 		// Get the form.
-		$form = $this->loadForm($this->typeAlias, 'category', array('control' => 'jform', 'load_data' => $loadData ));	
+		$form = $this->loadForm($this->typeAlias, 'category', array('control' => 'jform', 'load_data' => $loadData ));
+
+    // Apply filter to exclude child categories
+    $children = $form->getFieldAttribute('parent_id', 'children', 'true');
+    $children = filter_var($children, FILTER_VALIDATE_BOOLEAN);
+    if(!$children)
+    {
+      $form->setFieldAttribute('parent_id', 'exclude', $this->item->id);
+    }
 
 		// Apply filter for current category on thumbnail field
     $form->setFieldAttribute('thumbnail', 'categories', $this->item->id);

--- a/administrator/com_joomgallery/tmpl/categories/modal.php
+++ b/administrator/com_joomgallery/tmpl/categories/modal.php
@@ -1,0 +1,173 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2022  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 2 or later                          **
+*****************************************************************************************/
+ 
+// No direct access 
+defined('_JEXEC') or die;
+
+use \Joomla\CMS\HTML\HTMLHelper;
+use \Joomla\CMS\Factory;
+use \Joomla\CMS\Router\Route;
+use \Joomla\CMS\Layout\LayoutHelper;
+use \Joomla\CMS\Language\Text;
+use Joomla\CMS\Language\Multilanguage;
+use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+
+HTMLHelper::addIncludePath(JPATH_COMPONENT . '/src/Helper/');
+
+// Import CSS
+$wa = $this->document->getWebAssetManager();
+$wa->useStyle('com_joomgallery.admin')
+   ->useScript('com_joomgallery.admin');
+
+$input       = Factory::getApplication()->input;
+$field       = $input->getCmd('field');
+$listOrder   = $this->state->get('list.ordering');
+$listDirn    = $this->state->get('list.direction');
+$catRequired = (int) $input->get('required', 0, 'int');
+?>
+
+<form action="<?php echo Route::_('index.php?option=com_joomgallery&view=categories&layout=modal&tmpl=component'); ?>" method="post"
+	  name="adminForm" id="adminForm">
+	<div class="row">
+		<div class="col-md-12">
+			<div id="j-main-container" class="j-main-container">
+        <?php if (!$catRequired) : ?>
+          <div>
+            <button type="button" class="btn btn-primary button-select" data-category-value="1" data-category-title="<?php echo $this->escape('Root'); ?>" data-category-field="<?php echo $this->escape($field); ?>">
+              <?php echo Text::_('COM_JOOMGALLERY_NO_CATEGORY'); ?>
+            </button>
+          </div>
+        <?php endif; ?>
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<div class="clearfix"></div>
+        <div class="table-responsive">
+          <table class="table table-striped" id="categoryList">
+            <caption class="visually-hidden">
+							<?php echo Text::_('COM_JOOMGALLERY_CATEGORY_TABLE_CAPTION'); ?>,
+							<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+							<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+						</caption>
+            <thead>
+              <tr>
+                <th scope="col" class="w-1 text-center">
+                  <?php echo Text::_('JSTATUS'); ?>
+                </th>
+                <th scope="col" class="w-1 text-center">
+                  <?php echo Text::_('COM_JOOMGALLERY_IMAGE') ?>
+                </th>                
+                <th scope="col" style="min-width:100px">
+                  <?php echo HTMLHelper::_('searchtools.sort',  'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+                </th>
+                <th scope="col" class="w-10 d-none d-md-table-cell">
+                  <?php echo HTMLHelper::_('searchtools.sort',  'JGLOBAL_SHOW_PARENT_CATEGORY_LABEL', 'a.parent_id', $listDirn, $listOrder); ?>
+                </th>
+                <th scope="col" class="w-10 d-none d-md-table-cell">
+                  <?php echo Text::_('COM_JOOMGALLERY_IMAGES'); ?>
+                </th>
+                <th scope="col" class="w-10 d-none d-md-table-cell">
+                  <?php echo HTMLHelper::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+                </th>
+                <th scope="col" class="w-10 d-none d-md-table-cell">
+                  <?php echo HTMLHelper::_('searchtools.sort',  'COM_JOOMGALLERY_OWNER', 'a.created_by', $listDirn, $listOrder); ?>
+                </th>
+                <?php if (Multilanguage::isEnabled()) : ?>
+                  <th scope="col" class="w-10 d-none d-md-table-cell">
+                    <?php echo HTMLHelper::_('searchtools.sort',  'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+                  </th>
+                <?php endif; ?>
+                <th scope="col" class="w-3 d-none d-lg-table-cell"> 
+                  <?php echo HTMLHelper::_('searchtools.sort',  'JGLOBAL_FIELD_ID_LABEL', 'a.id', $listDirn, $listOrder); ?>
+                </th>
+              </tr>
+            </thead>
+            <tfoot>
+              <tr>
+                <td colspan="<?php echo isset($this->items[0]) ? count(get_object_vars($this->items[0])) : 10; ?>">
+                  <?php echo $this->pagination->getListFooter(); ?>
+                </td>
+              </tr>
+            </tfoot>
+            <tbody>
+              <?php foreach ($this->items as $i => $item) : ?>
+              <tr class="row<?php echo $i % 2; ?>">
+                <td class="text-center d-none d-md-table-cell">
+                  <div class="small badge-list">
+                    <?php if ($item->published === 1) : ?>
+                      <span class="badge bg-secondary">
+                        <?php echo Text::_('JPUBLISHED'); ?>
+                      </span>
+                    <?php else: ?>
+                      <span class="badge bg-secondary">
+                        <?php echo Text::_('JUNPUBLISHED'); ?>
+                      </span>
+                    <?php endif; ?>
+                  </div>
+                </td>
+
+                <td class="small d-none d-md-table-cell">
+                  <?php if(!empty($item->thumbnail)) : ?>
+                    <img class="jg_minithumb" src="<?php echo JoomHelper::getImg($item->thumbnail, 'thumbnail'); ?>" alt="<?php echo Text::_('COM_JOOMGALLERY_THUMBNAIL'); ?>">
+                  <?php endif; ?>
+                </td>
+
+                <th scope="row" class="has-context">
+                    <?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
+                    <a class="pointer button-select" href="#" data-category-value="<?php echo (int) $item->id; ?>" data-category-title="<?php echo $this->escape($item->title); ?>" data-category-field="<?php echo $this->escape($field); ?>">
+                      <?php echo $this->escape($item->title); ?>
+                    </a>
+
+                    <?php if ($item->hidden === 1) : ?>
+                      <div class="small">
+                        <span class="badge bg-secondary">
+                          <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                        </span>
+                      </div>
+                    <?php endif; ?>
+                </th>
+
+                <td class="d-none d-md-table-cell">
+                  <?php echo ($item->parent_title == 'Root') ? '' : $item->parent_title; ?>
+                </td>
+
+                <td class="d-none d-md-table-cell">
+                  <span class="badge bg-info"><?php echo (int) $item->img_count; ?></span>
+                </td>
+
+                <td class="small d-none d-md-table-cell">
+                  <?php echo $item->access; ?>
+                </td>
+                <td class="small d-none d-md-table-cell">
+                  <?php if ($item->created_by) : ?>
+                    <?php echo $this->escape($item->created_by); ?>
+                  <?php else : ?>
+                    <?php echo Text::_('JNONE'); ?>
+                  <?php endif; ?>
+                </td>
+                <?php if (Multilanguage::isEnabled()) : ?>
+                  <td class="small d-none d-md-table-cell">
+                    <?php echo LayoutHelper::render('joomla.content.language', $item); ?>
+                  </td>
+                <?php endif; ?>
+                <td>
+                  <?php echo $item->id; ?>
+                </td>
+              </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+				<input type="hidden" name="task" value=""/>
+				<input type="hidden" name="boxchecked" value="0"/>
+				<input type="hidden" name="list[fullorder]" value="<?php echo $listOrder; ?> <?php echo $listDirn; ?>"/>
+				<?php echo HTMLHelper::_('form.token'); ?>
+			</div>
+		</div>
+	</div>
+</form>

--- a/media/com_joomgallery/joomla.asset.json
+++ b/media/com_joomgallery/joomla.asset.json
@@ -40,6 +40,14 @@
       "attributes": {
         "type": "module"
       }
+    },
+    {
+      "name": "com_joomgallery.field-category",
+      "type": "script",
+      "uri": "com_joomgallery/field-category.js",
+      "attributes": {
+        "type": "module"
+      }
     }
   ]
 }

--- a/media/com_joomgallery/js/field-category.js
+++ b/media/com_joomgallery/js/field-category.js
@@ -1,0 +1,177 @@
+((customElements, Joomla) => {
+  class JoomGalleryFieldCategory extends HTMLElement {
+    constructor() {
+      super();
+      this.onCategorySelect = '';
+      this.onchangeStr = ''; // Bind events
+
+      this.buttonClick = this.buttonClick.bind(this);
+      this.iframeLoad = this.iframeLoad.bind(this);
+      this.modalClose = this.modalClose.bind(this);
+      this.setValue = this.setValue.bind(this);
+    }
+
+    static get observedAttributes() {
+      return ['url', 'modal', 'modal-width', 'modal-height', 'input', 'input-name', 'button-select'];
+    }
+
+    get url() {
+      return this.getAttribute('url');
+    }
+
+    set url(value) {
+      this.setAttribute('url', value);
+    }
+
+    get modalClass() {
+      return this.getAttribute('modal');
+    }
+
+    set modalClass(value) {
+      this.setAttribute('modal', value);
+    }
+
+    get modalWidth() {
+      return this.getAttribute('modal-width');
+    }
+
+    set modalWidth(value) {
+      this.setAttribute('modal-width', value);
+    }
+
+    get modalHeight() {
+      return this.getAttribute('modal-height');
+    }
+
+    set modalHeight(value) {
+      this.setAttribute('modal-height', value);
+    }
+
+    get inputId() {
+      return this.getAttribute('input');
+    }
+
+    set inputId(value) {
+      this.setAttribute('input', value);
+    }
+
+    get inputNameClass() {
+      return this.getAttribute('input-name');
+    }
+
+    set inputNameClass(value) {
+      this.setAttribute('input-name', value);
+    }
+
+    get buttonSelectClass() {
+      return this.getAttribute('button-select');
+    }
+
+    set buttonSelectClass(value) {
+      this.setAttribute('button-select', value);
+    }
+
+    connectedCallback() {
+      // Set up elements
+      this.modal = this.querySelector(this.modalClass);
+      this.modalBody = this.querySelector('.modal-body');
+      this.input = this.querySelector(this.inputId);
+      this.inputName = this.querySelector(this.inputNameClass);
+      this.buttonSelect = this.querySelector(this.buttonSelectClass); // Bootstrap modal init
+
+      if (this.modal && window.bootstrap && window.bootstrap.Modal && !window.bootstrap.Modal.getInstance(this.modal)) {
+        Joomla.initialiseModal(this.modal, {
+          isJoomla: true
+        });
+      }
+
+      if (this.buttonSelect) {
+        this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
+        this.modal.addEventListener('hide', this.removeIframe.bind(this)); // Check for onchange callback,
+
+        this.onchangeStr = this.input.getAttribute('data-onchange');
+
+        if (this.onchangeStr) {
+          /* eslint-disable */
+          this.onCategorySelect = new Function(this.onchangeStr);
+          this.input.addEventListener('change', this.onCategorySelect);
+          /* eslint-enable */
+        }
+      }
+    }
+
+    disconnectedCallback() {
+      if (this.onchangeStr && this.input) {
+        this.input.removeEventListener('change', this.onCategorySelect);
+      }
+
+      if (this.buttonSelect) {
+        this.buttonSelect.removeEventListener('click', this);
+      }
+
+      if (this.modal) {
+        this.modal.removeEventListener('hide', this);
+      }
+    }
+
+    buttonClick({
+      target
+    }) {
+      this.setValue(target.getAttribute('data-category-value'), target.getAttribute('data-category-title'));
+      this.modalClose();
+    }
+
+    iframeLoad() {
+      const iframeDoc = this.iframeEl.contentWindow.document;
+      const buttons = [].slice.call(iframeDoc.querySelectorAll('.button-select'));
+      buttons.forEach(button => {
+        button.addEventListener('click', this.buttonClick);
+      });
+    } // Opens the modal
+
+
+    modalOpen() {
+      // Reconstruct the iframe
+      this.removeIframe();
+      const iframe = document.createElement('iframe');
+      iframe.setAttribute('name', 'field-category-modal');
+      iframe.src = this.url.replace('{field-category-id}', this.input.getAttribute('id'));
+      iframe.setAttribute('width', this.modalWidth);
+      iframe.setAttribute('height', this.modalHeight);
+      this.modalBody.appendChild(iframe);
+      this.modal.open();
+      this.iframeEl = this.modalBody.querySelector('iframe'); // handle the selection on the iframe
+
+      this.iframeEl.addEventListener('load', this.iframeLoad);
+    } // Closes the modal
+
+
+    modalClose() {
+      Joomla.Modal.getCurrent().close();
+      this.modalBody.innerHTML = '';
+    } // Remove the iframe
+
+
+    removeIframe() {
+      this.modalBody.innerHTML = '';
+    } // Sets the value
+
+
+    setValue(value, name) {
+      this.input.setAttribute('value', value);
+      this.inputName.setAttribute('value', name || value); // trigger change event both on the input and on the custom element
+
+      this.input.dispatchEvent(new Event('change'));
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: {
+          value,
+          name
+        },
+        bubbles: true
+      }));
+    }
+
+  }
+
+  customElements.define('joomla-field-category', JoomGalleryFieldCategory);
+})(customElements, Joomla);


### PR DESCRIPTION
## What is this pull request for

It adds a new field to JoomGallery which allows to select a JoomGallery category using a modal box.
Clicking the button opens a modal box where you can search for the category. A click on the category name closes the modal and sets the category as new value in the field.
![grafik](https://user-images.githubusercontent.com/39154009/201527080-a3294b9e-e889-402e-9e8b-ee04a658956d.png)

The field is used in the category edit form to select a parent category.

## How to test this  pull request

Go to category manager, edit a category and select a parent category. Use filter and sorting options in the provided modal box to search for the correct category in your gallery.