### PR TITLE
Fix warning missing variable $saveOrderingUrl

### DIFF
--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -52,6 +52,12 @@ if($saveOrder && !empty($this->items))
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+        <?php if (empty($this->items)) : ?>
+          <div class="alert alert-info">
+            <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+            <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+          </div>
+        <?php else : ?>
 				<div class="clearfix"></div>
         <div class="table-responsive">
           <table class="table table-striped" id="categoryList">
@@ -252,6 +258,7 @@ if($saveOrder && !empty($this->items))
             </tbody>
           </table>
         </div>
+        <?php endif; ?>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
         <input type="hidden" id="del_force" name="del_force" value="0"/>

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -53,6 +53,12 @@ if($saveOrder && !empty($this->items))
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 			<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+        <?php if (empty($this->items)) : ?>
+          <div class="alert alert-info">
+            <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+            <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+          </div>
+        <?php else : ?>
 				<div class="clearfix"></div>
         <div class="table-responsive">
           <table class="table table-striped" id="imageList">
@@ -298,6 +304,7 @@ if($saveOrder && !empty($this->items))
             </tbody>
           </table>
         </div>
+        <?php endif; ?>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
 				<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/com_joomgallery/tmpl/tags/default.php
+++ b/administrator/com_joomgallery/tmpl/tags/default.php
@@ -49,6 +49,12 @@ if($saveOrder && !empty($this->items))
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 			<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+        <?php if (empty($this->items)) : ?>
+          <div class="alert alert-info">
+            <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+            <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+          </div>
+        <?php else : ?>
 				<div class="clearfix"></div>
         <div class="table-responsive">
           <table class="table table-striped" id="tagList">
@@ -192,6 +198,7 @@ if($saveOrder && !empty($this->items))
             </tbody>
           </table>
         </div>
+        <?php endif; ?>
 				<input type="hidden" name="task" value=""/>
 				<input type="hidden" name="boxchecked" value="0"/>
 				<?php /*<input type="hidden" name="list[fullorder]" value="<?php echo $listOrder; ?> <?php echo $listDirn; ?>"/> */ ?>


### PR DESCRIPTION
Fix Warning: Undefined variable $saveOrderingUrl ...
in images, categories and tags manager

## Steps to reproduce the issue

Go to image manager, category manager or tags manager.
Set sorting to 'ordering ascending'.
Apply a filter so that no item is found. Maybe access is 'Special' or like something.

## Expected result

A empty list or the message 'No Matching Results' like in Joomla should be shown.

## Actual result

A warning is shown: Warning: Undefined variable $saveOrderingUrl ...