### PR TITLE
Group action buttons in edit forms

### DIFF
--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -70,6 +70,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		$user  = Factory::getUser();
 		$isNew = ($this->item->id == 0);
 
@@ -90,30 +92,30 @@ class HtmlView extends JoomGalleryView
 		if(!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.create'))))
 		{
 			ToolbarHelper::apply('category.apply', 'JTOOLBAR_APPLY');
-			ToolbarHelper::save('category.save', 'JTOOLBAR_SAVE');
 		}
 
 		if(!$checkedOut && ($canDo->get('core.create')))
 		{
-			ToolbarHelper::custom('category.save2new', 'save-new.png', 'save-new_f2.png', 'JTOOLBAR_SAVE_AND_NEW', false);
-		}
+			$saveGroup = $toolbar->dropdownButton('save-group');
 
-		// If an existing item, can save to a copy.
-		if(!$isNew && $canDo->get('core.create'))
-		{ 
-      ToolbarHelper::save2copy('category.save2copy', 'JTOOLBAR_SAVE_AS_COPY');
+			$saveGroup->configure
+			(
+				function (Toolbar $childBar) use ($checkedOut, $canDo, $isNew)
+				{
+					$childBar->save('category.save', 'JTOOLBAR_SAVE');
 
-			// $toolbar = Toolbar::getInstance('toolbar');
+					if(!$checkedOut && ($canDo->get('core.create')))
+					{
+						$childBar->save2new('category.save2new');
+					}
 
-			// $dropdown = $toolbar->dropdownButton('save2copy-group')
-			// 	->text('JTOOLBAR_SAVE_AS_COPY')
-			// 	->toggleSplit(true)
-			// 	->icon('fa fa-ellipsis-h')
-			// 	->buttonClass('btn btn-action');
-
-			// $childBar = $dropdown->getChildToolbar();
-			// $childBar->save2copy('category.save2copy', 'JTOOLBAR_SAVE_AS_COPY');
-			// $childBar->save2copy('category.save2copy.recursive', 'JTOOLBAR_SAVE_AS_COPY_RECURSIVE');
+					// If an existing item, can save to a copy.
+					if(!$isNew && $canDo->get('core.create'))
+					{
+						$childBar->save2copy('category.save2copy');
+					}
+				}
+			);
 		}
 
 		if(empty($this->item->id))

--- a/administrator/com_joomgallery/src/View/Config/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Config/HtmlView.php
@@ -98,7 +98,8 @@ class HtmlView extends JoomGalleryView
 	protected function addToolbar()
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
-    	$toolbar = Toolbar::getInstance('toolbar');
+
+		$toolbar = Toolbar::getInstance('toolbar');
 
 		$user  = Factory::getUser();
 		$isNew = ($this->item->id == 0);
@@ -120,18 +121,36 @@ class HtmlView extends JoomGalleryView
 		if(!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.create'))))
 		{
 			ToolbarHelper::apply('config.apply', 'JTOOLBAR_APPLY');
-			ToolbarHelper::save('config.save', 'JTOOLBAR_SAVE');
+
+			$saveGroup = $toolbar->dropdownButton('save-group');
+
+			$saveGroup->configure
+			(
+				function (Toolbar $childBar) use ($checkedOut, $canDo, $isNew)
+				{
+					$childBar->save('config.save', 'JTOOLBAR_SAVE');
+
+					if(!$checkedOut && ($canDo->get('core.create')))
+					{
+						$childBar->save2new('config.save2new');
+					}
+
+					// If an existing item, can save to a copy.
+					if(!$isNew && $canDo->get('core.create'))
+					{
+						$childBar->save2copy('config.save2copy');
+					}
+				}
+			);
 		}
 
-		if(!$checkedOut && ($canDo->get('core.create')))
+		if(empty($this->item->id))
 		{
-			ToolbarHelper::custom('config.save2new', 'save-new.png', 'save-new_f2.png', 'JTOOLBAR_SAVE_AND_NEW', false);
+			ToolbarHelper::cancel('config.cancel', 'JTOOLBAR_CANCEL');
 		}
-
-		// If an existing item, can save to a copy.
-		if(!$isNew && $canDo->get('core.create'))
+		else
 		{
-			ToolbarHelper::custom('config.save2copy', 'save-copy.png', 'save-copy_f2.png', 'JTOOLBAR_SAVE_AS_COPY', false);
+			ToolbarHelper::cancel('config.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		if(!$isNew)
@@ -167,15 +186,6 @@ class HtmlView extends JoomGalleryView
 				'text' => Text::_('COM_JOOMGALLERY_IMPORT'));
 			$import_modal_btn = LayoutHelper::render('joomla.toolbar.popup', $import_modal_opt);
 			$toolbar->appendButton('Custom', $import_modal_btn);
-		}
-
-		if(empty($this->item->id))
-		{
-			ToolbarHelper::cancel('config.cancel', 'JTOOLBAR_CANCEL');
-		}
-		else
-		{
-			ToolbarHelper::cancel('config.cancel', 'JTOOLBAR_CLOSE');
 		}
 	}
 

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -14,6 +14,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
@@ -76,6 +77,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		$user  = Factory::getUser();
 		$isNew = ($this->item->id == 0);
 
@@ -96,23 +99,30 @@ class HtmlView extends JoomGalleryView
 		if(!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.create'))))
 		{
 			ToolbarHelper::apply('image.apply', 'JTOOLBAR_APPLY');
-			ToolbarHelper::save('image.save', 'JTOOLBAR_SAVE');
 		}
 
 		if(!$checkedOut && ($canDo->get('core.create')))
 		{
-			ToolbarHelper::custom('image.save2new', 'save-new.png', 'save-new_f2.png', 'JTOOLBAR_SAVE_AND_NEW', false);
-		}
+			$saveGroup = $toolbar->dropdownButton('save-group');
 
-		// If an existing item, can save to a copy.
-		if(!$isNew && $canDo->get('core.create'))
-		{
-			ToolbarHelper::custom('image.save2copy', 'save-copy.png', 'save-copy_f2.png', 'JTOOLBAR_SAVE_AS_COPY', false);
-		}
+			$saveGroup->configure
+            (
+				function (Toolbar $childBar) use ($checkedOut, $canDo, $isNew)
+				{
+					$childBar->save('image.save', 'JTOOLBAR_SAVE');
 
-		// Button for version control
-		if($this->state->params->get('save_history', 1) && $user->authorise('core.edit')) {
-			ToolbarHelper::versions('com_joomgallery.image', $this->item->id);
+					if(!$checkedOut && ($canDo->get('core.create')))
+					{
+						$childBar->save2new('image.save2new');
+					}
+
+					// If an existing item, can save to a copy.
+					if(!$isNew && $canDo->get('core.create'))
+					{
+						$childBar->save2copy('image.save2copy');
+					}
+				}
+			);
 		}
 
 		if(empty($this->item->id))

--- a/administrator/com_joomgallery/src/View/Tag/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tag/HtmlView.php
@@ -14,6 +14,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Tag;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
@@ -69,6 +70,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		$user  = Factory::getUser();
 		$isNew = ($this->item->id == 0);
 
@@ -89,18 +92,30 @@ class HtmlView extends JoomGalleryView
 		if(!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.create'))))
 		{
 			ToolbarHelper::apply('tag.apply', 'JTOOLBAR_APPLY');
-			ToolbarHelper::save('tag.save', 'JTOOLBAR_SAVE');
 		}
 
 		if(!$checkedOut && ($canDo->get('core.create')))
 		{
-			ToolbarHelper::custom('tag.save2new', 'save-new.png', 'save-new_f2.png', 'JTOOLBAR_SAVE_AND_NEW', false);
-		}
+			$saveGroup = $toolbar->dropdownButton('save-group');
 
-		// If an existing item, can save to a copy.
-		if(!$isNew && $canDo->get('core.create'))
-		{
-			ToolbarHelper::custom('tag.save2copy', 'save-copy.png', 'save-copy_f2.png', 'JTOOLBAR_SAVE_AS_COPY', false);
+			$saveGroup->configure
+			(
+				function (Toolbar $childBar) use ($checkedOut, $canDo, $isNew)
+				{
+					$childBar->save('tag.save', 'JTOOLBAR_SAVE');
+
+					if(!$checkedOut && ($canDo->get('core.create')))
+					{
+						$childBar->save2new('tag.save2new');
+					}
+
+					// If an existing item, can save to a copy.
+					if(!$isNew && $canDo->get('core.create'))
+					{
+						$childBar->save2copy('tag.save2copy');
+					}
+				}
+			);
 		}
 
 		if(empty($this->item->id))


### PR DESCRIPTION
In edit forms Joomla! groups 'Save & Close', 'Save & New' and 'Save as Copy' as a dropdown.
![group-action-buttons](https://user-images.githubusercontent.com/9802593/213918211-590b3a18-654d-4b74-81f5-89baa18e75f9.jpg)

This pr do this in the same way.