### PR TITLE
Fix problems with image processor ImageMagick

### DIFF
--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -931,7 +931,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     if(!$output)
     {
       // Get supported types of ImageMagick v6.x
-      @\exec(\trim($this->impath).'convert -version', $output);
+      @\exec(\trim($this->impath).'convert -list format', $output);
     }
 
     if(!$output)

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -285,7 +285,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     $file = Path::clean($file);
 
     // Set output quality
-    $this->commands['quality'] = ' -quality "'.$this->dst_imginfo['quality'].'"';
+    $this->commands['quality'] = ' -quality "'.$quality.'"';
 
     // Rotate image, if needed (use auto-orient command)
     if($this->auto_orient)


### PR DESCRIPTION
Fix two problems with image processor ImageMagick:

- Fixes problem "Unsupported image filetype". 
See https://github.com/JoomGalleryfriends/JG4-dev/issues/62 and https://github.com/JoomGalleryfriends/JG4-dev/issues/36
When using Imagemagick v6.x, the supported image types are not detected correctly.

- Fixes problem with quality parameter. 
Currently, the quality parameter from the configuration was not respected.

This PR should fix both problems.