### PR TITLE
Fix error when memory_limit is set to -1

### DIFF
--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -1576,16 +1576,16 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
 
       // Get memory limit in bytes
       $memory_limit = @\ini_get('memory_limit');
-      if(!empty($memory_limit) && $memory_limit != 0)
+      if(!empty($memory_limit) && !is_numeric($memory_limit))
       {
         $val          = \substr($memory_limit, -1);
         $memory_limit = \substr($memory_limit, 0, -1) * $byte_values[$val];
       }
 
-      if($memory_limit != 0 && $memoryNeeded > $memory_limit)
+      if($memory_limit >= 0 && $memoryNeeded > $memory_limit)
       {
         $memoryNeededMB = \round($memoryNeeded / $byte_values['M'], 0);
-        $memoryLimitMB  = \round($memory_limit / $byte_values['M'], 0);
+        $memoryLimitMB  = \round(intval($memory_limit) / $byte_values['M'], 0);
 
         return array('success' => false, 'needed' => $memoryNeededMB, 'limit' => $memoryLimitMB);
       }


### PR DESCRIPTION
The function checkMemory checks the value of memory_limit which is set in php.ini. Some hosters have set a value of -1 here. This 'unusual' value causes the check to fail.
This is a redo from https://github.com/JoomGalleryfriends/JoomGallery/pull/123