### PR TITLE
Rename field 'created by' to 'owner' 

### DIFF
--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -136,7 +136,7 @@
 
     <field name="created_by"
            type="user"
-           label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+           label="COM_JOOMGALLERY_OWNER"
            description="JGLOBAL_FIELD_CREATED_BY_DESC"
            validate="UserId" />
 

--- a/administrator/com_joomgallery/forms/image.xml
+++ b/administrator/com_joomgallery/forms/image.xml
@@ -151,8 +151,8 @@
 
     <field name="created_by"
            type="user"
-           label="JGLOBAL_FIELD_CREATED_BY_LABEL"
-           description="JGLOBAL_FIELD_CREATED_BY_DESC"
+           label="COM_JOOMGALLERY_OWNER"
+           description="COM_JOOMGALLERY_FIELDS_OWNER_DESC"
            validate="UserId" />
 
     <field name="modified_time"


### PR DESCRIPTION
Rename the field from 'created by' to 'owner' for images and categories as discussed here: https://github.com/JoomGalleryfriends/JG4-dev/issues/65
Only the 'displayed' name based on the language key is changed. 
The field in the database table itself has not been renamed, otherwise this would require larger changes.