### PR TITLE
Add warning message instead of fatal error

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -521,6 +521,7 @@ COM_JOOMGALLERY_SERVICE_CURRENT_TASK="Current task: %s."
 COM_JOOMGALLERY_SERVICE_PLEASE_WAIT_EXEC="Please wait while the requested task is executed. This may take some time."
 COM_JOOMGALLERY_SERVICE_PROGRESSBAR="(The progress bar will be refreshed approximately every %d seconds)"
 COM_JOOMGALLERY_SERVICE_ERROR_LOAD_CONFIG="Error: Configuration Set not properly loaded."
+COM_JOOMGALLERY_SERVICE_ERROR_UPLOAD_ANIMATED_WEBP="Error: Uploading WEBP files with animation is not possible."
 
 ; Plugin events
 COM_JOOMGALLERY_PLUGIN_ERROR_RETURN_VALUE="Return value of the plugin event '%s' must be of type %s and contain : %s"

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -264,10 +264,10 @@ abstract class IMGtools implements IMGtoolsInterface
       }
     }
 
-    // Detect, if image is a transparent webp image
+    // Detect, if image is a transparent or animated webp image
     if($this->src_type == 'WEBP')
     {
-      // Detect, if webp has transparency
+      // Detect, if webp has transparency or animation
       if($is_stream)
       {
         $webptype = \ord(\substr($img, 25, 1));
@@ -287,6 +287,28 @@ abstract class IMGtools implements IMGtoolsInterface
           {
             $this->res_imginfo['transparency'] = true;
           }
+        }
+
+        // Detect, if webp has animation
+        $included = strpos($webptype, "ANIM");
+        if($included !== FALSE)
+        {
+          $this->res_imginfo['animation'] = true;
+        }
+        else
+        {
+          $included = strpos($webptype, "ANMF");
+          if($included !== FALSE)
+          {
+            $this->res_imginfo['animation'] = true;
+          }
+        }
+
+        if($this->res_imginfo['animation'] == true)
+        {
+          $this->jg->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_ERROR_UPLOAD_ANIMATED_WEBP'));
+
+          return false;
         }
       }
     }


### PR DESCRIPTION
Currently, uploading an WEBP file with **'animation'** causes a Fatal Error when using GD as image processor, see https://github.com/JoomGalleryfriends/JG4-dev/pull/70#issuecomment-1450110906
This PR prevents the fatal error and issues a warning message instead.

However, what I don't understand is that if an invalid image type is detected (returning false in the analyse function), normally no record in the database table should be created or? An error in the service?