### PR TITLE
Solve visual problems in image manager

### DIFF
--- a/administrator/com_joomgallery/forms/filter_images.xml
+++ b/administrator/com_joomgallery/forms/filter_images.xml
@@ -24,11 +24,13 @@
         <field
               name="category"
               type="jgcategorydropdown"
+              layout="joomla.form.field.list-fancy-select"
               label="COM_JOOMGALLERY_COMMON_ALL"
               onchange="this.form.submit();"
               show_root="false"
               multiple="true"
               default=""
+              hint="JOPTION_SELECT_CATEGORY"
               message="COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY"
               task="filter" />
 

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -10,6 +10,7 @@
 ; So, do not translate this string {tip}!
 ; 
 ;Common 
+JGLOBAL_TYPE_OR_SELECT_CATEGORY="- Select Category -"
 JOOMGALLERY="JoomGallery"
 COM_JOOMGALLERY="JoomGallery"
 COM_JOOMGALLERY_CONFIGURATION="JoomGallery: Options"
@@ -236,6 +237,7 @@ COM_JOOMGALLERY_FIELDS_SELECT_IMAGE="Select an image"
 COM_JOOMGALLERY_FIELDS_SELECT_CATEGORY="Select a category"
 COM_JOOMGALLERY_FIELDS_SELECT_PARENT="- Select Parent -"
 COM_JOOMGALLERY_FIELDS_SELECT_EXCLUDE="- Select Exclude -"
+COM_JOOMGALLERY_FIELDS_SELECT_OWNER="- Select Owner -"
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Inheritance method of configuration"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -10,7 +10,6 @@
 ; So, do not translate this string {tip}!
 ; 
 ;Common 
-JGLOBAL_TYPE_OR_SELECT_CATEGORY="- Select Category -"
 JOOMGALLERY="JoomGallery"
 COM_JOOMGALLERY="JoomGallery"
 COM_JOOMGALLERY_CONFIGURATION="JoomGallery: Options"

--- a/administrator/com_joomgallery/src/Field/UserdropdownField.php
+++ b/administrator/com_joomgallery/src/Field/UserdropdownField.php
@@ -88,7 +88,7 @@ class UserdropdownField extends ListField
 		// "Please select" option when parameter multiple is false.
 		if($multiple == "false")
     {
-			$options[] = HTMLHelper::_('select.option', '', Text::_('JLIB_FORM_CHANGE_USER'));
+			$options[] = HTMLHelper::_('select.option', '', Text::_('COM_JOOMGALLERY_FIELDS_SELECT_OWNER'));
 		}
 
 		foreach($results as $result) 


### PR DESCRIPTION
@eumel1602  has reported here that there is a visual problem in the image manager:
https://github.com/JoomGalleryfriends/JG4-dev/pull/83#issuecomment-1486721378
In some selectboxes the texts are too long and cause a visual problem.
This PR fixes the problem by using the shorter texts as in Joomla itself. See texts in Joomla article manager.

I have tried to change the language constants in the forms/filter_images.xml. Unfortunately, this does not work.

For Category Select Box:
The previous text "Type or Select a Category" is loaded via the language constant JGLOBAL_TYPE_OR_SELECT_CATEGORY. This constant is used in line 71 of .../com_categories/layouts/form/field/categoryedit.php.
To shorten the text I only see the possibility to redefine the constant JGLOBAL_TYPE_OR_SELECT_CATEGORY in the language file com_joomgallery.ini.

For User select box:
For the selection of the owner I used the new constant COM_JOOMGALLERY_FIELDS_SELECT_OWNER in the UserdropdownField.php.