### PR TITLE
Fix PHP Deprecated messages when using php 8.1

### DIFF
--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -2502,7 +2502,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
             $bNew = 0;
           }
           $rgbNew = ($rNew << 16) + ($gNew << 8) + $bNew;
-          \imageSetPixel($img, $x, $y, $rgbNew);
+          \imageSetPixel($img, $x, $y, (int) $rgbNew);
         }
       }
     }

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -2451,7 +2451,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
 
           if(($rOrig != $rNew) || ($gOrig != $gNew) || ($bOrig != $bNew))
           {
-            $pixCol = \imageColorAllocate($img, $rNew, $gNew, $bNew);
+            $pixCol = \imageColorAllocate($img, (int) $rNew, (int) $gNew, (int) $bNew);
             \imageSetPixel($img, $x, $y, $pixCol);
           }
         }

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -142,7 +142,7 @@ class CategoryTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = Factory::getApplication()->input->get('task');
+		$task = (String) Factory::getApplication()->input->get('task');
 
 		if($array['id'] == 0)
 		{

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -142,7 +142,7 @@ class CategoryTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = (String) Factory::getApplication()->input->get('task');
+		$task = Factory::getApplication()->input->get('task', '', 'cmd');
 
 		if($array['id'] == 0)
 		{

--- a/administrator/com_joomgallery/src/Table/ConfigTable.php
+++ b/administrator/com_joomgallery/src/Table/ConfigTable.php
@@ -93,7 +93,7 @@ class ConfigTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = Factory::getApplication()->input->get('task');
+		$task = (String) Factory::getApplication()->input->get('task');
 
 		if($array['id'] == 0 && empty($array['created_by']))
 		{

--- a/administrator/com_joomgallery/src/Table/ConfigTable.php
+++ b/administrator/com_joomgallery/src/Table/ConfigTable.php
@@ -93,7 +93,7 @@ class ConfigTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = (String) Factory::getApplication()->input->get('task');
+		$task = Factory::getApplication()->input->get('task', '', 'cmd');
 
 		if($array['id'] == 0 && empty($array['created_by']))
 		{

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -132,7 +132,7 @@ class ImageTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = (String) Factory::getApplication()->input->get('task');
+		$task = Factory::getApplication()->input->get('task', '', 'cmd');
 
 
 		// Support for alias field: alias

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -132,7 +132,7 @@ class ImageTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = Factory::getApplication()->input->get('task');
+		$task = (String) Factory::getApplication()->input->get('task');
 
 
 		// Support for alias field: alias

--- a/administrator/com_joomgallery/src/Table/TagTable.php
+++ b/administrator/com_joomgallery/src/Table/TagTable.php
@@ -95,7 +95,7 @@ class TagTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = (String) Factory::getApplication()->input->get('task');
+		$task = Factory::getApplication()->input->get('task', '', 'cmd');
 
     // Support for alias field: alias
 		if(empty($array['alias']))

--- a/administrator/com_joomgallery/src/Table/TagTable.php
+++ b/administrator/com_joomgallery/src/Table/TagTable.php
@@ -95,7 +95,7 @@ class TagTable extends Table implements VersionableTableInterface
 	public function bind($array, $ignore = '')
 	{
 		$date = Factory::getDate();
-		$task = Factory::getApplication()->input->get('task');
+		$task = (String) Factory::getApplication()->input->get('task');
 
     // Support for alias field: alias
 		if(empty($array['alias']))


### PR DESCRIPTION
When using PHP 8.1 and Error Reporting = Maximum, there are PHP Deprecated messages.
These warning messages cause e.g. in the image manager that no thumbnails are displayed.

The problem is always the bind function in which ...\strpos($task, 'save')... is used to check for the presence of a string in the '$task' variable.
If $task is NULL, however, this message appears.
Enclosed is a suggestion how to prevent this message. Maybe there is a better suggestion?