### PR TITLE
Fix approve button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /.idea/fileTemplates/includes/PHP Property Doc Comment.php
 /.idea/inspectionProfiles/Project_Default.xml
 /.idea/vcs.xml
+node_modules

--- a/administrator/com_joomgallery/src/Controller/ImagesController.php
+++ b/administrator/com_joomgallery/src/Controller/ImagesController.php
@@ -51,7 +51,7 @@ class ImagesController extends JoomAdminController
 		$this->registerTask('featured', 'feature');
     $this->registerTask('unfeatured', 'feature');
 
-    $this->registerTask('approveded', 'approve');
+    $this->registerTask('approved', 'approve');
     $this->registerTask('unapproved', 'approve');
   }
 
@@ -211,7 +211,7 @@ class ImagesController extends JoomAdminController
         break;
 
       case 'approve':
-        $data  = array('approve' => 1, 'unapprove' => 0);
+        $data  = array('approved' => 1, 'unapproved' => 0);
         $msgs  = array('APPROVING', 'APPROVED', 'UNAPPROVED', '', '');
         break;
       
@@ -224,7 +224,7 @@ class ImagesController extends JoomAdminController
 
     $value = ArrayHelper::getValue($data, $task, 0, 'int');
 
-		if (empty($cid))
+		if(empty($cid))
 		{
 			$this->app->getLogger()->warning(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), array('image' => 'jerror'));
 		}

--- a/administrator/com_joomgallery/src/Helper/ApprovedButton.php
+++ b/administrator/com_joomgallery/src/Helper/ApprovedButton.php
@@ -33,8 +33,8 @@ class ApprovedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(1, 'unapprove', 'approve', Text::_('COM_JOOMGALLERY_UNAPPROVE_ITEM'), ['tip_title' => Text::_('COM_JOOMGALLERY_APPROVED')]);
-		$this->addState(0, 'approve', 'unapprove', Text::_('COM_JOOMGALLERY_APPROVE_ITEM'), ['tip_title' => Text::_('COM_JOOMGALLERY_UNAPPROVED')]);
+		$this->addState(1, 'unapproved', 'approve', Text::_('COM_JOOMGALLERY_UNAPPROVE_ITEM'), ['tip_title' => Text::_('COM_JOOMGALLERY_APPROVED')]);
+		$this->addState(0, 'approved', 'unapprove', Text::_('COM_JOOMGALLERY_APPROVE_ITEM'), ['tip_title' => Text::_('COM_JOOMGALLERY_UNAPPROVED')]);
 	}
 
 	/**


### PR DESCRIPTION
Before this PR the approve button did not work korrectly. It was not possible to unapprove an image once it was approved using the images view.

With this PR this should work now.