### PR TITLE
Replace imagetype

### DIFF
--- a/administrator/com_joomgallery/forms/image.xml
+++ b/administrator/com_joomgallery/forms/image.xml
@@ -260,6 +260,22 @@
            type="hidden"
            filter="stirng" />
 
+    <field name="replacetype"
+           type="jgimagetype"
+           label="COM_JOOMGALLERY_IMAGETYPE"
+           description="COM_JOOMGALLERY_FIELDS_REPLACE_IMAGETYPE_DESC" />
+
+    <field name="replaceprocess"
+           type="radio"
+           default="0"
+           class="btn-group"
+           layout="joomla.form.field.radio.switcher"
+           label="COM_JOOMGALLERY_CONFIG_TAB_IMAGE_PROCESSING"
+           description="COM_JOOMGALLERY_FIELDS_REPLACE_IMAGETYPE_PROCESS_DESC">
+        <option value="0">JNO</option>
+        <option value="1">JYES</option>
+    </field>
+
     <field name="imgdate"
            type="calendar"
            format="%Y-%m-%d"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -18,6 +18,7 @@ COM_JOOMGALLERY_MAINTENANCE="Maintenance"
 COM_JOOMGALLERY_MIGRATIONS="Migration"
 COM_JOOMGALLERY_IMAGE="Image"
 COM_JOOMGALLERY_IMAGES="Images"
+COM_JOOMGALLERY_IMAGETYPE="Image-Type"
 COM_JOOMGALLERY_NO_IMAGE="No image"
 COM_JOOMGALLERY_TAG="Tag"
 COM_JOOMGALLERY_TAGS="Tags"
@@ -73,6 +74,7 @@ COM_JOOMGALLERY_MULTIPLE_NEW="Multiple New"
 COM_JOOMGALLERY_DEBUG_MODE="Debug Mode"
 COM_JOOMGALLERY_IMAGE_SELECTION="Image selection"
 COM_JOOMGALLERY_IMAGE_SOURCE="Source"
+COM_JOOMGALLERY_REPLACE="Replace"
 
 ;Types
 COM_JOOMGALLERY_THUMBNAIL="Thumbnail"
@@ -226,6 +228,8 @@ COM_JOOMGALLERY_ERROR_UPPY_UPLOAD="Upload of file {filename} using Uppy failed."
 COM_JOOMGALLERY_ERROR_UPPY_FORM="Required fields in form has to be filled! Please fill in the form before starting to upload.."
 COM_JOOMGALLERY_ERROR_UPPY_SAVE_RECORD="Save record to database of file '{filename}' failed."
 COM_JOOMGALLERY_ERROR_FILL_REQUIRED_FIELDS="Please fill in required fields."
+COM_JOOMGALLERY_ERROR_REPLACE_IMAGETYPE="Image-Type (%s) successfully replaced."
+COM_JOOMGALLERY_SUCCESS_IMAGETYPE="Image-Type (%s) could not be replaced. Error: %s."
 
 ;Mail Templates
 COM_JOOMGALLERY_MAIL_NEWIMAGE_TITLE="JoomGallery: New Image"
@@ -260,6 +264,8 @@ COM_JOOMGALLERY_FIELDS_SELECT_OWNER="- Select Owner -"
 COM_JOOMGALLERY_FIELDS_DEBUG_MODE_DESC="With activated debug mode all processing steps will be shown. In case you are admin or of errors they are always displayed."
 COM_JOOMGALLERY_FIELDS_NUMBERING_START="Numbering start"
 COM_JOOMGALLERY_FIELDS_NUMBERING_START_DESC="Start numbering images with the following value."
+COM_JOOMGALLERY_FIELDS_REPLACE_IMAGETYPE_DESC="Select the image type to replace."
+COM_JOOMGALLERY_FIELDS_REPLACE_IMAGETYPE_PROCESS_DESC="Yes to process the image before replacement (resize, watermarking, ...)."
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Configuration inheritance"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -230,6 +230,8 @@ COM_JOOMGALLERY_ERROR_UPPY_SAVE_RECORD="Save record to database of file '{filena
 COM_JOOMGALLERY_ERROR_FILL_REQUIRED_FIELDS="Please fill in required fields."
 COM_JOOMGALLERY_ERROR_REPLACE_IMAGETYPE="Image-Type (%s) successfully replaced."
 COM_JOOMGALLERY_SUCCESS_IMAGETYPE="Image-Type (%s) could not be replaced. Error: %s."
+COM_JOOMGALLERY_SUCCESS_REPLACE_IMAGETYPE="Image-Type (%s) successfully replaced."
+COM_JOOMGALLERY_ERROR_REPLACE_IMAGETYPE="Image-Type (%s) could not be replaced. Error: %s."
 
 ;Mail Templates
 COM_JOOMGALLERY_MAIL_NEWIMAGE_TITLE="JoomGallery: New Image"
@@ -508,6 +510,7 @@ COM_JOOMGALLERY_SERVICE_GD_SUPPORTED_TYPES="ERROR: GD is processing only %s file
 COM_JOOMGALLERY_SERVICE_RESIZE_NOT_NEEDED="Resize is not necessary because the image is already small enough."
 COM_JOOMGALLERY_SERVICE_ROTATE_NOT_NEEDED="Rotation is not necessary."
 COM_JOOMGALLERY_SERVICE_FLIP_NOT_NEEDED="Flipping the image is not necessary."
+COM_JOOMGALLERY_SERVICE_MANIPULATION_NOT_NEEDED="No image manipulation needed."
 COM_JOOMGALLERY_SERVICE_MANIPULATION_SUCCESSFUL="Image manipulation successful."
 COM_JOOMGALLERY_SERVICE_SUPPORTED_TYPES="Image types supported by this image processor: %s"
 COM_JOOMGALLERY_SERVICE_ERROR_CLEAN_FILENAME="Error cleaning up filename (%s)."

--- a/administrator/com_joomgallery/src/Controller/ImageController.php
+++ b/administrator/com_joomgallery/src/Controller/ImageController.php
@@ -241,4 +241,26 @@ class ImageController extends JoomFormController
     // Redirect to the list screen.
     $this->setRedirect(Route::_($url, false));
   }
+
+  /**
+     * Method to cancel an edit.
+     *
+     * @param   string  $key  The name of the primary key of the URL variable.
+     *
+     * @return  boolean  True if access level checks pass, false otherwise.
+     *
+     * @since   1.6
+     */
+    public function cancel($key = null)
+    {
+      parent::cancel($key);
+
+      if($this->input->get('layout', 'edit', 'cmd') == 'replace')
+      {
+        // Redirect to the edit screen.
+        $this->setRedirect(
+          Route::_('index.php?option=' . $this->option . '&view=image&layout=edit&id=' . $this->input->getInt('id'), false)
+        );
+      }
+    }
 }

--- a/administrator/com_joomgallery/src/Controller/ImageController.php
+++ b/administrator/com_joomgallery/src/Controller/ImageController.php
@@ -12,10 +12,10 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Router\Route;
 use \Joomla\CMS\Response\JsonResponse;
-use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Factory;
+use \Joomla\CMS\MVC\Controller\FormController;
+use \Joomla\CMS\Router\Route;
 use \Joomla\CMS\Language\Text;
 
 /**
@@ -152,10 +152,10 @@ class ImageController extends JoomFormController
     // Access check.
     if (!$this->allowSave($data, $id))
     {
-      $app->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
+      $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
       $this->setRedirect(
-        Route::_('index.php?option=' . _JOOM_OPTION . '&view=' . $this->view_list. $this->getRedirectToListAppend(),false)
+        Route::_('index.php?option=' . _JOOM_OPTION . '&view=' . $this->view_list . $this->getRedirectToListAppend(),false)
       );
 
       return false;
@@ -165,7 +165,7 @@ class ImageController extends JoomFormController
     $form = $model->getForm($data, false);
     if(!$form)
     {
-      $app->enqueueMessage($model->getError(), 'error');
+      $this->setMessage($model->getError(), 'error');
       return false;
     }
     $form->setFieldAttribute('imgtitle', 'required', false);
@@ -186,11 +186,11 @@ class ImageController extends JoomFormController
       {
         if ($errors[$i] instanceof \Exception)
         {
-          $app->enqueueMessage($errors[$i]->getMessage(), 'warning');
+          $this->setMessage($errors[$i]->getMessage(), 'warning');
         }
         else
         {
-          $app->enqueueMessage($errors[$i], 'warning');
+          $this->setMessage($errors[$i], 'warning');
         }
       }
 
@@ -212,7 +212,7 @@ class ImageController extends JoomFormController
       $app->setUserState($context . '.data', $validData);
 
       // Redirect back to the replace screen.
-      $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_REPLACE_IMAGETYPE', \ucfirst($validData['replacetype']), $model->getError()), 'error');
+      $this->setMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_REPLACE_IMAGETYPE', \ucfirst($validData['replacetype']), $model->getError()), 'error');
 
       $this->setRedirect(
           Route::_('index.php?option=' . _JOOM_OPTION . '&view=image&layout=replace&id=' . $id, false)
@@ -222,7 +222,7 @@ class ImageController extends JoomFormController
     }
 
     // Set message
-    $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_IMAGETYPE', \ucfirst($validData['replacetype'])));
+    $this->setMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_REPLACE_IMAGETYPE', \ucfirst($validData['replacetype'])));
 
     // Clear the data from the session.
     $app->setUserState($context . '.data', null);

--- a/administrator/com_joomgallery/src/Field/JgimagetypeField.php
+++ b/administrator/com_joomgallery/src/Field/JgimagetypeField.php
@@ -1,0 +1,58 @@
+<?php
+/** 
+******************************************************************************************
+**   @version    4.0.0                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2022  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 2 or later                          **
+*****************************************************************************************/
+
+namespace Joomgallery\Component\Joomgallery\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use \Joomla\CMS\HTML\HTMLHelper;
+use \Joomla\CMS\Form\Field\ListField;
+use \Joomla\CMS\Language\Text;
+use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+
+class JgimagetypeField extends ListField
+{
+  /**
+	 * A dropdown field with all activated imagetypes
+	 *
+	 * @var    string
+	 * @since  1.6
+	 */
+	public $type = 'jgimagetype';
+
+  /**
+	 * Method to get a list of categories that respects access controls and can be used for
+	 * either category assignment or parent category assignment in edit screens.
+	 * Use the parent element to indicate that the field will be used for assigning parent categories.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   1.6
+	 */
+	protected function getOptions()
+	{	
+    // Get all imagetypes	
+		$imagetypes = JoomHelper::getRecords('imagetypes');
+
+		// Prepare the empty array
+		$options = array();
+
+		foreach($imagetypes as $imagetype) 
+		{
+      if($imagetype->params->get('jg_imgtype', '1'))
+      {
+        $options[] = HTMLHelper::_('select.option', $imagetype->typename, Text::_('COM_JOOMGALLERY_'.\strtoupper($imagetype->typename)));
+      }			
+		}
+
+		return $options;
+	}
+
+}

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -998,6 +998,9 @@ class ImageModel extends JoomAdminModel
       $uploader->type         = $data['replacetype'];
       $uploader->processImage = \boolval($data['replaceprocess']);
 
+      // Set filename in data since it will not be new created during retrieveImage()
+      $data['filename']       = $table->filename;
+
       // Retrieve image
       // (check upload, check user upload limit, create filename, onJoomBeforeSave)
       if(!$uploader->retrieveImage($data, false))

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -962,6 +962,72 @@ class ImageModel extends JoomAdminModel
     return $this->changeSate($pks, 'publish', $value);
   }
 
+  /**
+	 * Method to replace an image type.
+	 *
+	 * @param   array  $data  The form data.
+	 *
+	 * @return  boolean  True on success, False on error.
+	 *
+	 * @since   4.0.0
+	 */
+	public function replace($data)
+	{
+    $table = $this->getTable();
+		$app   = Factory::getApplication();
+		$key   = $table->getKeyName();
+		$pk    = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+		
+		// Rertrieve request image file data
+    if(\array_key_exists('image', $app->input->files->get('jform')) && !empty($app->input->files->get('jform')['image'])
+    && $app->input->files->get('jform')['image']['error'] != 4 &&  $app->input->files->get('jform')['image']['size'] > 0)
+		{
+			$data['images'] = array();
+			\array_push($data['images'], $app->input->files->get('jform')['image']);
+		}
+
+    try
+    {
+      // Load image table
+      $table->load($pk);
+
+      // Create uploader service
+      $uploader = JoomHelper::getService('uploader', array('single', false));
+
+      // Set replacement settings
+      $uploader->type         = $data['replacetype'];
+      $uploader->processImage = \boolval($data['replaceprocess']);
+
+      // Retrieve image
+      // (check upload, check user upload limit, create filename, onJoomBeforeSave)
+      if(!$uploader->retrieveImage($data, false))
+      {
+        $this->setError($this->component->getDebug(true));
+
+        return false;
+      }
+
+      // Create images
+      // (create imagetypes, upload imagetypes to storage, onJoomAfterUpload)
+      if(!$uploader->createImage($table))
+      {
+        $uploader->rollback();
+        $this->setError($this->component->getDebug(true));
+
+        return false;
+      }
+    }
+    catch (\Exception $e)
+		{
+			$uploader->rollback();
+			$this->setError($e->getMessage());
+
+			return false;
+		}
+
+    return true;
+  }
+
 	/**
 	 * Prepare and sanitise the table prior to saving.
 	 *

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -1016,6 +1016,9 @@ class ImageModel extends JoomAdminModel
 
         return false;
       }
+
+      // Clean the cache.
+			$this->cleanCache();
     }
     catch (\Exception $e)
 		{
@@ -1023,6 +1026,12 @@ class ImageModel extends JoomAdminModel
 			$this->setError($e->getMessage());
 
 			return false;
+		}
+
+    // Output debug data
+		if(\count($this->component->getDebug()) > 1)
+		{
+			$this->component->printDebug();
 		}
 
     return true;

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -229,6 +229,10 @@ class FileManager implements FileManagerInterface
           }
         }
       }
+      else
+      {
+        $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_MANIPULATION_NOT_NEEDED'));
+      }
 
       // Path to save image
       $file = $this->getImgPath(0, $imagetype->typename, $cat, $filename, false);

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -60,12 +60,14 @@ class FileManager implements FileManagerInterface
 
   /**
    * Constructor
+   * 
+   * @param   array|bool     $selection    List of imagetypes to consider or false to consider all (default: False)
    *
    * @return  void
    *
    * @since   1.0.0
    */
-  public function __construct()
+  public function __construct($selection=False)
   {
     // Load application
     $this->getApp();
@@ -81,6 +83,12 @@ class FileManager implements FileManagerInterface
 
     // Get imagetypes
     $this->getImagetypes();
+
+    // Apply imagetype selection
+    if($selection !== False)
+    {
+      $this->selectImagetypes($selection);
+    }
   }
 
   /**
@@ -88,15 +96,16 @@ class FileManager implements FileManagerInterface
    * Source file has to be given with a full system path.
    * 
    *
-   * @param   string               $source     Source file with which the image types shall be created
-   * @param   string               $filename   Name for the files to be created
-   * @param   object|int|string    $cat        Object, ID or alias of the corresponding category (default: 2)
+   * @param   string               $source        Source file with which the image types shall be created
+   * @param   string               $filename      Name for the files to be created
+   * @param   object|int|string    $cat           Object, ID or alias of the corresponding category (default: 2)
+   * @param   bool                 $processing    True to create imagetypes by processing source (defualt: True)
    * 
    * @return  bool                 True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function createImages($source, $filename, $cat=2): bool
+  public function createImages($source, $filename, $cat=2, $processing=True): bool
   {
     if(!$filename)
     {
@@ -122,98 +131,102 @@ class FileManager implements FileManagerInterface
       // Debug info
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_PROCESSING_IMAGETYPE', $imagetype->typename), true, true);
 
-      // Keep metadata only for original images
-      if($imagetype->typename == 'original')
+      // Process image
+      if($processing)
       {
-        $this->component->getIMGtools()->keep_metadata = true;
-      }
-      else
-      {
-        $this->component->getIMGtools()->keep_metadata = false;
-      }
-
-      // Do we need to keep animation?
-      if($imagetype->params->get('jg_imgtypeanim', 0) == 1)
-      {
-        // Yes
-        $this->component->getIMGtools()->keep_anim = true;
-      }
-      else
-      {
-        // No
-        $this->component->getIMGtools()->keep_anim = false;
-      }
-      
-      // Read source image
-      if(!$this->component->getIMGtools()->read($source))
-      {
-        // Destroy the IMGtools service
-        $this->component->delIMGtools();
-
-        // Debug info
-        $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-
-        continue;
-      }
-
-      // Do we need to auto orient?
-      if($imagetype->params->get('jg_imgtypeorinet', 0) == 1)
-      {
-        // Yes
-        if(!$this->component->getIMGtools()->orient())
-        {  
-          // Destroy the IMGtools service
-          $this->component->delIMGtools();
-
-          // Debug info
-          $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $error = true;
-
-          continue;
+        // Keep metadata only for original images
+        if($imagetype->typename == 'original')
+        {
+          $this->component->getIMGtools()->keep_metadata = true;
         }
-      }
+        else
+        {
+          $this->component->getIMGtools()->keep_metadata = false;
+        }
 
-      // Need for resize?
-      if($imagetype->params->get('jg_imgtyperesize', 0) > 0)
-      {
-        // Yes
-        if(!$this->component->getIMGtools()->resize($imagetype->params->get('jg_imgtyperesize', 3),
-                                             $imagetype->params->get('jg_imgtypewidth', 5000),
-                                             $imagetype->params->get('jg_imgtypeheight', 5000),
-                                             $imagetype->params->get('jg_cropposition', 2),
-                                             $imagetype->params->get('jg_imgtypesharpen', 0))
-          )
+        // Do we need to keep animation?
+        if($imagetype->params->get('jg_imgtypeanim', 0) == 1)
+        {
+          // Yes
+          $this->component->getIMGtools()->keep_anim = true;
+        }
+        else
+        {
+          // No
+          $this->component->getIMGtools()->keep_anim = false;
+        }
+        
+        // Read source image
+        if(!$this->component->getIMGtools()->read($source))
         {
           // Destroy the IMGtools service
           $this->component->delIMGtools();
 
           // Debug info
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $error = true;
 
           continue;
         }
-      }
 
-      // Need for watermarking?
-      if($imagetype->params->get('jg_imgtypewatermark', 0) == 1)
-      {
-        // Yes
-        if(!$this->component->getIMGtools()->watermark(JPATH_ROOT.\DIRECTORY_SEPARATOR.$this->component->getConfig()->get('jg_wmfile'),
-                                                $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkpos', 9),
-                                                $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkzoom', 0),
-                                                $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarksize', 15),
-                                                $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkopacity', 80))
-          )
+        // Do we need to auto orient?
+        if($imagetype->params->get('jg_imgtypeorinet', 0) == 1)
         {
-          // Destroy the IMGtools service
-          $this->component->delIMGtools();
+          // Yes
+          if(!$this->component->getIMGtools()->orient())
+          {  
+            // Destroy the IMGtools service
+            $this->component->delIMGtools();
 
-          // Debug info
-          $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $error = true;
+            // Debug info
+            $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
+            $error = true;
 
-          continue;
+            continue;
+          }
+        }
+
+        // Need for resize?
+        if($imagetype->params->get('jg_imgtyperesize', 0) > 0)
+        {
+          // Yes
+          if(!$this->component->getIMGtools()->resize($imagetype->params->get('jg_imgtyperesize', 3),
+                                              $imagetype->params->get('jg_imgtypewidth', 5000),
+                                              $imagetype->params->get('jg_imgtypeheight', 5000),
+                                              $imagetype->params->get('jg_cropposition', 2),
+                                              $imagetype->params->get('jg_imgtypesharpen', 0))
+            )
+          {
+            // Destroy the IMGtools service
+            $this->component->delIMGtools();
+
+            // Debug info
+            $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
+            $error = true;
+
+            continue;
+          }
+        }
+
+        // Need for watermarking?
+        if($imagetype->params->get('jg_imgtypewatermark', 0) == 1)
+        {
+          // Yes
+          if(!$this->component->getIMGtools()->watermark(JPATH_ROOT.\DIRECTORY_SEPARATOR.$this->component->getConfig()->get('jg_wmfile'),
+                                                  $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkpos', 9),
+                                                  $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkzoom', 0),
+                                                  $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarksize', 15),
+                                                  $imagetype->params->get('jg_imgtypewtmsettings.jg_watermarkopacity', 80))
+            )
+          {
+            // Destroy the IMGtools service
+            $this->component->delIMGtools();
+
+            // Debug info
+            $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
+            $error = true;
+
+            continue;
+          }
         }
       }
 
@@ -254,9 +267,16 @@ class FileManager implements FileManagerInterface
         continue;
       }
 
-      // Write image to file
-      $image_content = $this->component->getIMGtools()->stream($imagetype->params->get('jg_imgtypequality', 100), false);
-      //$this->component->getIMGtools()->write($file, $imagetype->params->get('jg_imgtypequality', 100))
+      // Get image stream
+      if($processing)
+      {
+        $image_content = $this->component->getIMGtools()->stream($imagetype->params->get('jg_imgtypequality', 100), false);
+      }
+      else
+      {
+        $image_content = \file_get_contents($source);
+      }
+
       if(!$image_content)
       {
         // Destroy the IMGtools service
@@ -1258,6 +1278,45 @@ class FileManager implements FileManagerInterface
     $this->imagetypes = \array_reverse($this->imagetypes);
 
     // create dictionary for imagetypes array
+    foreach ($this->imagetypes as $key => $imagetype)
+    {
+      $this->imagetypes_dict[$imagetype->typename] = $key;
+    }
+  }
+
+  /**
+   * Delete all imagetypes which are not selected
+   * 
+   * @param   array||string    $selection    Name or list of names of imagetypes to consider
+   * 
+   * @return  void
+   * 
+   * @since   4.0.0
+   */
+  protected function selectImagetypes($selection)
+  {
+    if(empty($this->imagetypes))
+    {
+      return;
+    }
+
+    if(!\is_array($selection))
+    {
+      $selection = array($selection);
+    }
+
+    foreach($this->imagetypes as $key =>$imagetype)
+    {
+      if(!\in_array($imagetype->typename, $selection))
+      {
+        // unselected imagetype
+        unset($this->imagetypes[$key]);
+      }
+    }
+
+    $this->imagetypes = array_values($this->imagetypes);
+
+    // update dictionary for imagetypes array
     foreach ($this->imagetypes as $key => $imagetype)
     {
       $this->imagetypes_dict[$imagetype->typename] = $key;

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
@@ -26,17 +26,20 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\FileManager;
 interface FileManagerInterface
 {
   /**
-   * Creation of image types
+   * Creation of image types based on source file.
+   * Source file has to be given with a full system path.
+   * 
    *
-   * @param   string               $source     Source file for which the image types shall be created
-   * @param   string               $filename   Name for the files to be created
-   * @param   object|int|string    $cat        Object, ID or alias of the corresponding category (default: 2)
+   * @param   string               $source        Source file with which the image types shall be created
+   * @param   string               $filename      Name for the files to be created
+   * @param   object|int|string    $cat           Object, ID or alias of the corresponding category (default: 2)
+   * @param   bool                 $processing    True to create imagetypes by processing source (defualt: True)
    * 
    * @return  bool                 True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function createImages($source, $filename, $cat=2): bool;
+  public function createImages($source, $filename, $cat=2, $processing=True): bool;
 
   /**
    * Deletion of image types

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManagerServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManagerServiceTrait.php
@@ -44,14 +44,16 @@ trait FileManagerServiceTrait
 
   /**
 	 * Creates the file manager helper class
+   * 
+   * @param   array|bool     $selection    List of imagetypes to consider or false to consider all (default: False)
 	 *
    * @return  void
    *
 	 * @since  4.0.0
 	 */
-	public function createFileManager(): void
+	public function createFileManager($selection=False): void
 	{
-    $this->fileManager = new FileManager();
+    $this->fileManager = new FileManager($selection);
 
     return;
 	}

--- a/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
@@ -224,4 +224,28 @@ class SingleUploader extends BaseUploader implements UploaderInterface
       return Text::sprintf('COM_JOOMGALLERY_ERROR_CODE', Text::_('COM_JOOMGALLERY_ERROR_UNKNOWN'));
     }
   }
+
+  /**
+   * Detect if there is an image uploaded
+   * 
+   * @param   array    $data      Form data
+   * 
+   * @return  bool     True if file is detected, false otherwise
+   * 
+   * @since   4.0.0
+   */
+  public function isImgUploaded($data): bool
+  {
+    $app  = Factory::getApplication();
+
+    if(\array_key_exists('image', $app->input->files->get('jform')) && !empty($app->input->files->get('jform')['image'])
+    && $app->input->files->get('jform')['image']['error'] != 4 &&  $app->input->files->get('jform')['image']['size'] > 0)
+		{
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
 }

--- a/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
@@ -16,18 +16,33 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Filesystem\File as JFile;
 use \Joomla\CMS\Filesystem\Path as JPath;
-
+use \Joomgallery\Component\Joomgallery\Administrator\Table\ImageTable;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\Uploader as BaseUploader;
 
 /**
-* Uploader helper class (Standard HTML Upload)
+* Uploader helper class (Single Image Upload)
 *
 * @since  4.0.0
 */
-class HTMLUploader extends BaseUploader implements UploaderInterface
+class SingleUploader extends BaseUploader implements UploaderInterface
 {
-	/**
+
+  /**
+   * The imagetype to create
+   *
+   * @var string
+   */
+  public $type = 'original';
+
+  /**
+   * Does images have to be processed?
+   *
+   * @var bool
+   */
+  public $processImage = False;
+
+  /**
 	 * Method to retrieve an uploaded image. Step 1.
    * (check upload, check user upload limit, create filename, onJoomBeforeUpload)
 	 *
@@ -41,14 +56,6 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
 	public function retrieveImage(&$data, $filename=True): bool
   {
     $user = Factory::getUser();
-    $app  = Factory::getApplication();
-
-    // Retrieve request image file data
-    if(\array_key_exists('image', $app->input->files->get('jform')) && !empty($app->input->files->get('jform')['image']))
-    {
-      $data['images'] = array();
-      \array_push($data['images'], $app->input->files->get('jform')['image']);
-    }
 
     if(\count($data['images']) > 1)
     {
@@ -59,7 +66,7 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_IMAGE_NBR_PROCESSING', $this->filecounter + 1));
     }
 
-    $image = $data['images'][$this->filecounter-1];
+    $image = $data['images'][$this->filecounter];
 
     // Check for upload error codes
     if($image['error'] > 0)
@@ -76,27 +83,39 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
       return false;
     }
 
-    // Get number of uploaded images of the current user
-    $counter = $this->getImageNumber($user->get('id'));
-
-    // Check if user already exceeds its upload limit
-    if($this->app->isClient('site') && $counter > ($this->component->getConfig()->get('jg_maxuserimage') - 1) && $user->get('id'))
-    {
-      $timespan = $this->component->getConfig()->get('jg_maxuserimage_timespan');
-      $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_UPLOAD_OUTPUT_MAY_ADD_MAX_OF', $this->component->getConfig()->get('jg_maxuserimage'), $timespan > 0 ? Text::plural('COM_JOOMGALLERY_UPLOAD_NEW_IMAGE_MAXCOUNT_TIMESPAN', $timespan) : ''));
-
-      return false;
-    }
-
     $this->src_tmp  = $image['tmp_name'];
     $this->src_name = $image['name'];
     $this->src_size = $image['size'];
 
-    // Perform the parent method
-    // - check tag and size
-    // - create filename
-    // - trigger onJoomBeforeUpload
-    if(!parent::retrieveImage($data, $filename))
+    // Create filesystem service
+    $this->component->createFilesystem();
+
+    // Get extension
+    $tag = $this->component->getFilesystem()->getExt($this->src_name);
+
+    // Get supported formats of image processor
+    $this->component->createIMGtools($this->component->getConfig()->get('jg_imgprocessor'));
+    $supported_ext = $this->component->getIMGtools()->get('supported_types');
+    $allowed_imgtools = \in_array(\strtoupper($tag), $supported_ext);
+    $this->component->delIMGtools();
+
+    // Get supported formats of filesystem    
+    $allowed_filesystem = $this->component->getFilesystem()->isAllowedFile($this->src_name);
+
+    // Check for supported image format
+    if(!$allowed_imgtools || !$allowed_filesystem || strlen($this->src_tmp) == 0 || $this->src_tmp == 'none')
+    {
+      $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_UNSUPPORTED_IMAGEFILE_TYPE'));
+      $this->error  = true;
+
+      return false;
+    }
+
+    $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_FILENAME', $this->src_name));
+
+    // Trigger onJoomBeforeUpload
+    $plugins  = $this->app->triggerEvent('onJoomBeforeUpload', array($data['filename']));
+    if(in_array(false, $plugins, true))
     {
       return false;
     }
@@ -132,14 +151,49 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
    */
   public function overrideData(&$data): bool
   {
-    // Get upload date
-    if(empty($data['imgdate']) || \strpos($data['imgdate'], '1900-01-01') !== false)
+    return true;
+  }
+
+  /**
+	 * Method to create uploaded image files. Step 3.
+   * (create imagetype, upload imagetypes to storage, onJoomAfterUpload)
+	 *
+   * @param   ImageTable   $data_row     Image object
+   *
+	 * @return  bool         True on success, false otherwise
+	 *
+	 * @since  4.0.0
+	 */
+	public function createImage($data_row): bool
+  {
+    // Check if filename was set
+    if(!isset($data_row->filename) || empty($data_row->filename))
     {
-      $data['imgdate'] = $data['created_time'];
+      throw new \Exception(Text::_('COM_JOOMGALLERY_SERVICE_UPLOAD_CHECK_FILENAME'));
+    }    
+    
+    // Create file manager service
+    $this->component->createFileManager(array($this->type));
+
+    // Process image to create imagetype
+    if(!$this->component->getFileManager()->createImages($this->src_file, $data_row->filename, $data_row->catid, $this->processImage))
+    {
+      $this->rollback($data_row);
+      $this->error = true;
+
+      return false;
     }
 
-    // Override form data with image metadata
-    return parent::overrideData($data);
+    $this->component->addDebug(' ');
+    $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SUCCESS_CREATE_IMAGETYPE_END'));
+    $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_FILENAME', $data_row->filename));
+
+    $this->app->triggerEvent('onJoomAfterUpload', array($data_row));
+
+    // Reset user states
+    $this->resetUserStates();
+
+    return !$this->error;
   }
 
   /**
@@ -168,30 +222,6 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
     else
     {
       return Text::sprintf('COM_JOOMGALLERY_ERROR_CODE', Text::_('COM_JOOMGALLERY_ERROR_UNKNOWN'));
-    }
-  }
-
-  /**
-   * Detect if there is an image uploaded
-   * 
-   * @param   array    $data      Form data
-   * 
-   * @return  bool     True if file is detected, false otherwise
-   * 
-   * @since   4.0.0
-   */
-  public function isImgUploaded($data): bool
-  {
-    $app  = Factory::getApplication();
-
-    if(\array_key_exists('image', $app->input->files->get('jform')) && !empty($app->input->files->get('jform')['image'])
-    && $app->input->files->get('jform')['image']['error'] != 4 &&  $app->input->files->get('jform')['image']['size'] > 0)
-		{
-      return true;
-    }
-    else
-    {
-      return false;
     }
   }
 }

--- a/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
@@ -66,7 +66,7 @@ class SingleUploader extends BaseUploader implements UploaderInterface
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_IMAGE_NBR_PROCESSING', $this->filecounter + 1));
     }
 
-    $image = $data['images'][$this->filecounter];
+    $image = $data['images'][$this->filecounter-1];
 
     // Check for upload error codes
     if($image['error'] > 0)

--- a/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
@@ -14,6 +14,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\HTMLUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\TUSUploader;
+use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\SingleUploader;
+use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\BatchUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\FTPUploader;
 
 /**
@@ -62,6 +64,13 @@ trait UploaderServiceTrait
       case 'TUS':
 			case 'tus':
         $this->uploader = new TUSUploader($multiple, $async);
+
+      case 'single':
+        $this->uploader = new SingleUploader($multiple);
+        break;
+
+      case 'batch':
+        $this->uploader = new BatchUploader($multiple);
         break;
 
       case 'FTP':

--- a/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
@@ -15,7 +15,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\HTMLUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\TUSUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\SingleUploader;
-use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\BatchUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\FTPUploader;
 
 /**
@@ -67,10 +66,6 @@ trait UploaderServiceTrait
 
       case 'single':
         $this->uploader = new SingleUploader($multiple);
-        break;
-
-      case 'batch':
-        $this->uploader = new BatchUploader($multiple);
         break;
 
       case 'FTP':

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -82,6 +82,15 @@ class HtmlView extends JoomGalleryView
 
       $this->js_vars = $js_vars;
     }
+    elseif($this->_layout == 'replace')
+    {
+      if($this->item->id == 0)
+      {
+        throw new \Exception("View needs an image ID to be loaded.", 1);
+      }
+      $this->addToolbarReplace();
+      $this->modifyFieldsReplace();
+    }
     else
     {
       $this->addToolbarEdit();
@@ -217,5 +226,54 @@ class HtmlView extends JoomGalleryView
     }
 
     return $types;
+  }
+
+  /**
+	 * Add the page title and toolbar for the imagetype replace form.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception
+	 */
+	protected function addToolbarReplace()
+	{
+    Factory::getApplication()->input->set('hidemainmenu', true);
+
+    ToolbarHelper::title(Text::_('COM_JOOMGALLERY_IMAGES').' :: '.Text::_('COM_JOOMGALLERY_REPLACE'), "image");
+
+    $canDo = JoomHelper::getActions();
+
+    // Add replace button
+		if($canDo->get('core.edit'))
+		{
+			ToolbarHelper::save('image.replace', 'COM_JOOMGALLERY_REPLACE');
+		}
+  }
+
+  /**
+	 * Modify form fields according to view needs.
+	 *
+	 * @return void
+	 *
+	 */
+	protected function modifyFieldsReplace()
+	{
+    $this->form->setFieldAttribute('imgtitle', 'required', false);
+    $this->form->setFieldAttribute('replacetype', 'required', true);
+    $this->form->setFieldAttribute('image', 'required', true);
+    $this->form->setFieldAttribute('catid', 'required', false);
+
+    $this->form->setFieldAttribute('id', 'type', 'hidden');
+
+    $this->form->setFieldAttribute('imgtitle', 'readonly', true);
+    $this->form->setFieldAttribute('alias', 'readonly', true);
+    $this->form->setFieldAttribute('catid', 'readonly', true);
+
+    if($this->app->input->get('type', '', 'string') !== '')
+    {
+      $this->form->setFieldAttribute('replacetype', 'readonly', true);
+    }    
+
+    $this->form->setFieldAttribute('replacetype', 'default', $this->app->input->get('type', 'original', 'string'));
   }
 }

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -248,6 +248,9 @@ class HtmlView extends JoomGalleryView
 		{
 			ToolbarHelper::save('image.replace', 'COM_JOOMGALLERY_REPLACE');
 		}
+
+    // Add cancel button
+    ToolbarHelper::cancel('image.cancel', 'JTOOLBAR_CANCEL');
   }
 
   /**

--- a/administrator/com_joomgallery/tmpl/image/edit.php
+++ b/administrator/com_joomgallery/tmpl/image/edit.php
@@ -178,9 +178,10 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
 </form>
 
 <?php
+// Image preview modal
 $options = array('modal-dialog-scrollable' => true,
                   'title'  => 'Test Title',
-                  'footer' => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'.Text::_('JCLOSE').'</button>',
+                  'footer' => '<a id="replaceBtn" class="btn" href="'.Route::_('index.php?option=com_joomgallery&view=image&layout=replace&id='.(int) $this->item->id).'">'.Text::_('COM_JOOMGALLERY_REPLACE').'</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'.Text::_('JCLOSE').'</button>',
                 );
 
 echo HTMLHelper::_('bootstrap.renderModal', 'image-modal-box', $options, '<div id="modal-body">Content set by ajax.</div>');
@@ -193,6 +194,7 @@ echo HTMLHelper::_('bootstrap.renderModal', 'image-modal-box', $options, '<div i
 
     let modalTitle = modal.querySelector('.modal-title');
     let modalBody  = modal.querySelector('.modal-body');
+    let modalBtn   = document.getElementById('replaceBtn');
 
     <?php
       $imgURL   = '{';
@@ -216,6 +218,8 @@ echo HTMLHelper::_('bootstrap.renderModal', 'image-modal-box', $options, '<div i
     body      = body + '<img src="' + imgURL[typename] + '" alt="' + imgTitle[typename] + '">';
     body      = body + '</div>';
     modalBody.innerHTML  = body;
+
+    modalBtn.href = modalBtn.href + '&type=' + typename;
 
     let bsmodal = new bootstrap.Modal(document.getElementById('image-modal-box'), {keyboard: false});
     bsmodal.show();

--- a/administrator/com_joomgallery/tmpl/image/replace.php
+++ b/administrator/com_joomgallery/tmpl/image/replace.php
@@ -1,0 +1,74 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2022  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 2 or later                          **
+*****************************************************************************************/
+
+// No direct access 
+defined('_JEXEC') or die;
+
+use \Joomla\CMS\Factory;
+use \Joomla\CMS\Router\Route;
+use \Joomla\CMS\Language\Text;
+use \Joomla\CMS\HTML\HTMLHelper;
+
+// Uppy config
+$uppy_version = 'v3.5.0'; // Uppy version to use
+
+HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+$wa = $this->document->getWebAssetManager();
+$wa->useScript('keepalive')
+	 ->useScript('form.validate')
+   ->useStyle('com_joomgallery.admin');
+HTMLHelper::_('bootstrap.tooltip');
+
+$app = Factory::getApplication();
+
+// In case of modal
+$isModal = $app->input->get('layout') === 'modal';
+$layout  = $isModal ? 'modal' : 'edit';
+$tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+?>
+
+<div class="jg jg-img-replace">
+  <form
+    action="<?php echo Route::_('index.php?option=com_joomgallery&layout='.$layout.$tmpl); ?>"
+    method="post" enctype="multipart/form-data" name="adminForm" id="image-form" class="form-validate"
+    aria-label="<?php echo Text::_('COM_JOOMGALLERY_IMAGES_UPLOAD', true); ?>" >
+
+    <div class="row align-items-start">
+      <div class="col-xxl-auto col-md-6 mb">
+        <div class="card">
+          <div class="card-header">
+            <h2><?php echo Text::_('COM_JOOMGALLERY_REPLACE'); ?></h2>
+          </div>
+          <div class="card-body">
+            <?php echo $this->form->renderField('replacetype'); ?>
+            <?php echo $this->form->renderField('replaceprocess'); ?>
+            <?php echo $this->form->renderField('image'); ?>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card">
+          <div class="card-header">
+            <h2><?php echo Text::_('COM_JOOMGALLERY_IMAGE'); ?></h2>
+          </div>
+          <div class="card-body">
+            <?php echo $this->form->renderField('imgtitle'); ?>
+            <?php echo $this->form->renderField('alias'); ?>
+            <?php echo $this->form->renderField('id'); ?>
+            <?php echo $this->form->renderField('catid'); ?>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <input type="hidden" name="task" value=""/>
+    <?php echo HTMLHelper::_('form.token'); ?>
+  </form>
+</div>

--- a/administrator/com_joomgallery/tmpl/image/replace.php
+++ b/administrator/com_joomgallery/tmpl/image/replace.php
@@ -68,6 +68,8 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
       </div>
     </div>
 
+    <input type="hidden" name="id" value="<?php echo $this->item->id; ?>"/>
+    <input type="hidden" name="layout" value="replace"/>
     <input type="hidden" name="task" value=""/>
     <?php echo HTMLHelper::_('form.token'); ?>
   </form>


### PR DESCRIPTION
This PR adds the functionality to replace/exchange a specific imagetype (thumbnail, detail, original, ...). This is useful for example, if you are not satisfied with an automatic processing result and you want to create the image for this imagetype locally by hand and then replace it.
In the Image edit view there is now a "Replace" button in the preview modal of each imagetype. This button brings you to a from view where you can select/upload the image used for replacement.
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/733dc0bc-7c05-4609-ad07-a9af9d5b86b8)

Replacement form view
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/58e4dc49-9013-4633-953f-e40ac5b376fc)
The left side is to be filled out. The right side gives you the info on which image you are working on.