### PR TITLE
prevent php deprecated warning

### DIFF
--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -820,7 +820,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
       $images = array_map(
         'trim',
         array_filter(
-          explode(',',$this->component->getConfig()->get('jg_imagetypes',null)),
+          explode(',',$this->component->getConfig()->get('jg_imagetypes', '')),
           fn($value) => !is_null($value) && $value !== ''
         )
       );
@@ -828,7 +828,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
       $audios = array_map(
         'trim',
         array_filter(
-          explode(',',$this->component->getConfig()->get('jg_audiotypes',null)),
+          explode(',',$this->component->getConfig()->get('jg_audiotypes', '')),
           fn($value) => !is_null($value) && $value !== ''
         )
       );
@@ -836,7 +836,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
       $videos = array_map(
         'trim',
         array_filter(
-          explode(',',$this->component->getConfig()->get('jg_videotypes',null)),
+          explode(',',$this->component->getConfig()->get('jg_videotypes', '')),
           fn($value) => !is_null($value) && $value !== ''
         )
       );
@@ -844,7 +844,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
       $documents = array_map(
         'trim',
         array_filter(
-          explode(',',$this->component->getConfig()->get('jg_documenttypes',null)),
+          explode(',',$this->component->getConfig()->get('jg_documenttypes', '')),
           fn($value) => !is_null($value) && $value !== ''
         )
       );

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -825,6 +825,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
         )
       );
 
+/* not used currently
       $audios = array_map(
         'trim',
         array_filter(
@@ -848,10 +849,12 @@ class Filesystem implements AdapterInterface, FilesystemInterface
           fn($value) => !is_null($value) && $value !== ''
         )
       );
+*/
 
       foreach($types as $type)
       {
-        if(in_array($type, ['images', 'audios', 'videos', 'documents']))
+        // not used currently:  if(in_array($type, ['images', 'audios', 'videos', 'documents']))
+        if(in_array($type, ['images']))
         {
           $extensions = array_merge($extensions, ${$type});
         }

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -801,6 +801,15 @@ class Filesystem implements AdapterInterface, FilesystemInterface
             case '0':
               $types[] = 'images';
               break;
+            case '1':
+              $types[] = 'audios';
+              break;
+            case '2':
+              $types[] = 'videos';
+              break;
+            case '3':
+              $types[] = 'documents';
+              break;
             default:
               break;
           }
@@ -816,8 +825,35 @@ class Filesystem implements AdapterInterface, FilesystemInterface
         )
       );
 
+/* not used currently
+      $audios = array_map(
+        'trim',
+        array_filter(
+          explode(',',$this->component->getConfig()->get('jg_audiotypes',null)),
+          fn($value) => !is_null($value) && $value !== ''
+        )
+      );
+
+      $videos = array_map(
+        'trim',
+        array_filter(
+          explode(',',$this->component->getConfig()->get('jg_videotypes',null)),
+          fn($value) => !is_null($value) && $value !== ''
+        )
+      );
+
+      $documents = array_map(
+        'trim',
+        array_filter(
+          explode(',',$this->component->getConfig()->get('jg_documenttypes',null)),
+          fn($value) => !is_null($value) && $value !== ''
+        )
+      );
+*/
+
       foreach($types as $type)
       {
+        // not used currently:  if(in_array($type, ['images', 'audios', 'videos', 'documents']))
         if(in_array($type, ['images']))
         {
           $extensions = array_merge($extensions, ${$type});

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -801,15 +801,6 @@ class Filesystem implements AdapterInterface, FilesystemInterface
             case '0':
               $types[] = 'images';
               break;
-            case '1':
-              $types[] = 'audios';
-              break;
-            case '2':
-              $types[] = 'videos';
-              break;
-            case '3':
-              $types[] = 'documents';
-              break;
             default:
               break;
           }
@@ -825,35 +816,8 @@ class Filesystem implements AdapterInterface, FilesystemInterface
         )
       );
 
-/* not used currently
-      $audios = array_map(
-        'trim',
-        array_filter(
-          explode(',',$this->component->getConfig()->get('jg_audiotypes',null)),
-          fn($value) => !is_null($value) && $value !== ''
-        )
-      );
-
-      $videos = array_map(
-        'trim',
-        array_filter(
-          explode(',',$this->component->getConfig()->get('jg_videotypes',null)),
-          fn($value) => !is_null($value) && $value !== ''
-        )
-      );
-
-      $documents = array_map(
-        'trim',
-        array_filter(
-          explode(',',$this->component->getConfig()->get('jg_documenttypes',null)),
-          fn($value) => !is_null($value) && $value !== ''
-        )
-      );
-*/
-
       foreach($types as $type)
       {
-        // not used currently:  if(in_array($type, ['images', 'audios', 'videos', 'documents']))
         if(in_array($type, ['images']))
         {
           $extensions = array_merge($extensions, ${$type});

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -825,7 +825,6 @@ class Filesystem implements AdapterInterface, FilesystemInterface
         )
       );
 
-/* not used currently
       $audios = array_map(
         'trim',
         array_filter(
@@ -849,12 +848,10 @@ class Filesystem implements AdapterInterface, FilesystemInterface
           fn($value) => !is_null($value) && $value !== ''
         )
       );
-*/
 
       foreach($types as $type)
       {
-        // not used currently:  if(in_array($type, ['images', 'audios', 'videos', 'documents']))
-        if(in_array($type, ['images']))
+        if(in_array($type, ['images', 'audios', 'videos', 'documents']))
         {
           $extensions = array_merge($extensions, ${$type});
         }


### PR DESCRIPTION
Fix PHP deprected warnings:
```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in \administrator\components\com_joomgallery\src\Service\Filesystem\Filesystem.php on line 831
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in \administrator\components\com_joomgallery\src\Service\Filesystem\Filesystem.php on line 839
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in \administrator\components\com_joomgallery\src\Service\Filesystem\Filesystem.php on line 847
```

It tries to read values from the configuration that are not existent.
The code is only commented out so that it can be easily reactivated later.
See also https://github.com/JoomGalleryfriends/JG4-dev/pull/132#issuecomment-1705452052