### PR TITLE
Fix warning "Deprecated: Function strftime() is deprecated..." when editing images

### DIFF
--- a/administrator/com_joomgallery/forms/image.xml
+++ b/administrator/com_joomgallery/forms/image.xml
@@ -281,7 +281,7 @@
            format="%Y-%m-%d"
            timeformat="24"
            filter="server_utc"
-           translateformat="false"
+           translateformat="true"
            showtime="false"
            singleheader="false"
            todaybutton="true"


### PR DESCRIPTION
PHP 8.1: The use of the calendar field seems to generate this warning in Joomla in general.
It should be sufficient to change in the xml file to **_translateformat="true"_**. I don't know if there is a better solution?
See also: https://github.com/JoomGalleryfriends/JG4-dev/issues/131#issue-1877971439