### PR TITLE
Fixes a layout problem in the uppy dashboard

### DIFF
--- a/administrator/com_joomgallery/tmpl/image/upload.php
+++ b/administrator/com_joomgallery/tmpl/image/upload.php
@@ -65,7 +65,7 @@ $wa->addInlineScript('window.uppyVars = JSON.parse(\''. json_encode($this->js_va
     novalidate aria-label="<?php echo Text::_('COM_JOOMGALLERY_IMAGES_UPLOAD', true); ?>" >
 
     <div class="row align-items-start">
-      <div class="col-xxl-auto col-md-6 mb"> 
+      <div class="col-md-6 mb"> 
         <div class="card">
           <div class="card-header">
             <h2><?php echo Text::_('COM_JOOMGALLERY_IMAGE_SELECTION'); ?></h2>

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -186,3 +186,6 @@ joomla-field-image .jg_minithumb {
 .uppy-Dashboard-Item-state {
   margin-bottom: 5px;
 }
+.uppy-Dashboard-Item-name {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Currently there are shifts in the following lines in uppy dashboard for images with long file names.
There is also an empty space between the uppy dashboard and the input fields on the right.
This PR should fix this problem.