### PR TITLE
Fix error in script when upgrade from JG3 to JG4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 /.idea/inspectionProfiles/Project_Default.xml
 /.idea/vcs.xml
 /administrator/com_joomgallery/joomgallery.xml
+/administrator/com_joomgallery/joomgallery_old.xml
 node_modules

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -109,6 +109,18 @@ class CategoryTable extends Table implements VersionableTableInterface
 	}
 
   /**
+	 * Resets the root_id property to the default value: 0
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+  public static function resetRootId()
+  {
+    self::$root_id = 0;
+  }
+
+  /**
 	 * Define a namespaced asset name for inclusion in the #__assets table
 	 *
 	 * @return string The asset name

--- a/script.php
+++ b/script.php
@@ -59,11 +59,26 @@ class com_joomgalleryInstallerScript extends InstallerScript
   protected $new_code = '';
 
   /**
+   * Counter variable
+   *
+   * @var  int
+   */
+  protected $count = 0;
+
+  /**
    * True to skip output during install() method
    *
    * @var  bool
    */
   protected $installSkipMsg = false;
+
+  /**
+   * True to show that the current script is exectuted during an upgrade
+   * from an old JoomGallery version (JG 1-3)
+   *
+   * @var  bool
+   */
+  protected $fromOldJG = false;
 
 
 	/**
@@ -271,6 +286,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     {
       // We update from an old version (JG 1-3)
       $this->installSkipMsg = true;
+      $this->fromOldJG      = true;
       $this->install($parent);
     }
     else
@@ -390,7 +406,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
    */
   function postflight($type, $parent)
   {
-    if($type == 'install')
+    if($type == 'install' || ($type == 'update' && $this->fromOldJG))
     {
       $app = Factory::getApplication();
 

--- a/script.php
+++ b/script.php
@@ -854,35 +854,47 @@ class com_joomgalleryInstallerScript extends InstallerScript
 	/**
 	 * Uninstalls plugins
 	 *
-	 * @param   mixed  $parent  Object who called the uninstall method
+	 * @param   mixed  $parent  Object who called the uninstall method or array with plugin names
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	private function uninstallPlugins($parent)
 	{
 		$app = Factory::getApplication();
 
-		if(method_exists($parent, 'getManifest'))
-		{
-			$plugins = $parent->getManifest()->plugins;
-		}
-		else
-		{
-			$plugins = $parent->get('manifest')->plugins;
-		}
-
-    if(!$plugins || empty($plugins->children()) || count($plugins->children()) <= 0)
+    if(is_array($parent))
     {
-      return;
+      // We got an array of module names
+      $modules = $parent;
     }
+    else
+    {
+      // We got the parent object
+      if(method_exists($parent, 'getManifest'))
+      {
+        $plugins = $parent->getManifest()->plugins;
+      }
+      else
+      {
+        $plugins = $parent->get('manifest')->plugins;
+      }
+
+      if(!$plugins || empty($plugins->children()) || count($plugins->children()) <= 0)
+      {
+        return;
+      }
+
+      $plugins = $plugins->children();
+    }		
 
     $db    = Factory::getContainer()->get(DatabaseInterface::class);
     $query = $db->getQuery(true);
 
-    foreach($plugins->children() as $plugin)
+    foreach($plugins as $plugin)
     {
       $pluginName  = (string) $plugin['plugin'];
       $pluginGroup = (string) $plugin['group'];
+      
       $query
         ->clear()
         ->select('extension_id')
@@ -941,17 +953,19 @@ class com_joomgalleryInstallerScript extends InstallerScript
       {
         $modules = $parent->get('manifest')->modules;
       }
-    }
 
-    if(!$modules || empty($modules->children()) || count($modules->children()) <= 0)
-    {
-      return;
-    }
+      if(!$modules || empty($modules->children()) || count($modules->children()) <= 0)
+      {
+        return;
+      }
+
+      $modules = $modules->children();
+    }    
 
     $db    = Factory::getContainer()->get(DatabaseInterface::class);
     $query = $db->getQuery(true);
 
-    foreach($modules->children() as $module)
+    foreach($modules as $module)
     {
       if(is_array($parent))
       {

--- a/script.php
+++ b/script.php
@@ -163,6 +163,13 @@ class com_joomgalleryInstallerScript extends InstallerScript
         }
       }
 
+      // copy old XML file (JGv1-3)
+      $xml_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR;
+      if(File::exists($xml_path.'joomgallery.xml'))
+      {
+        File::copy($xml_path.'joomgallery.xml', $xml_path.'joomgallery_old.xml');
+      }
+
       // remove old JoomGallery files and folders
       foreach($this->detectJGfolders() as $folder)
       {

--- a/script.php
+++ b/script.php
@@ -208,6 +208,8 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     if($this->installSkipMsg)
     {
+      // Skip install method here if we upgrade from an old version
+      // and we don't want to show the install text.
       return;
     }
 

--- a/script.php
+++ b/script.php
@@ -545,7 +545,8 @@ class com_joomgalleryInstallerScript extends InstallerScript
     require_once $class_path;
 
     if(class_exists($tableClass))
-    {      
+    {
+      $tableClass::resetRootId();
       $table = new $tableClass($db);
     }
     else

--- a/script.php
+++ b/script.php
@@ -1340,7 +1340,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
       $row->language  = $lang;
       if(!$row->store())
       {
-        $app->enqueueMessage(Text::_('Unable to create "'.$title.'" module!'), 'error');
+        Factory::getApplication()->enqueueMessage(Text::_('Unable to create "'.$title.'" module!'), 'error');
 
         return false;
       }

--- a/script.php
+++ b/script.php
@@ -156,7 +156,6 @@ class com_joomgalleryInstallerScript extends InstallerScript
       if($jgtables)
       {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
-
         foreach($jgtables as $oldTable)
         {
           $db->renameTable($oldTable, $oldTable.'_old');
@@ -230,7 +229,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     // Create news feed module
     $subdomain = '';
-    $language = Factory::getLanguage();
+    $language = Factory::getContainer()->get(LanguageFactoryInterface::class);
     if(strpos($language->getTag(), 'de-') === false)
     {
       $subdomain = 'en.';

--- a/script.php
+++ b/script.php
@@ -11,15 +11,16 @@
 defined('_JEXEC') or die();
 
 use \Joomla\CMS\Factory;
-use \Joomla\Database\DatabaseInterface;
-use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Router\Route;
-use \Joomla\CMS\Installer\Installer;
-use \Joomla\CMS\Installer\InstallerScript;
-use \Joomla\CMS\Filesystem\File;
-use \Joomla\CMS\Filesystem\Folder;
 use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Table\Table;
+use \Joomla\CMS\Language\Text;
+use \Joomla\CMS\Router\Route;
+use \Joomla\CMS\Filesystem\File;
+use \Joomla\CMS\Filesystem\Folder;
+use \Joomla\CMS\Installer\Installer;
+use \Joomla\CMS\Installer\InstallerScript;
+use \Joomla\Database\DatabaseInterface;
+use \Joomla\CMS\Language\LanguageFactoryInterface;
 
 /**
  * Install method

--- a/script.php
+++ b/script.php
@@ -230,7 +230,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     // Create news feed module
     $subdomain = '';
-    $language = Factory::getContainer()->get(LanguageFactoryInterface::class);
+    $language = $app->getLanguage();
     if(strpos($language->getTag(), 'de-') === false)
     {
       $subdomain = 'en.';


### PR DESCRIPTION
Upgrade from JG3 to JG4 created an error, when script tries to uninstall modules during the upgrading process. Line 180 of script.php `$this->uninstallModules(array('mod_joomgithub'));` throws an error because it tries to call method `children()` on variable type array.

Thanks @csoscd for reporting this issue.