### PR TITLE
Show categories without images

### DIFF
--- a/script.php
+++ b/script.php
@@ -541,6 +541,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $data["description"] = "";
     $data["access"] = 1;
     $data["published"] = 1;
+    $data["thumbnail"] = "0";
     $data["params"] = '{"allow_download":"-1","allow_comment":"-1","allow_rating":"-1","allow_watermark":"-1","allow_watermark_download":"-1"}';
     $data["language"] = "*";
     $data["metadesc"] = "";

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -162,7 +162,7 @@ class CategoryModel extends JoomItemModel
     $listModel->setState('filter.access', $user->getAuthorisedViewLevels());
     $listModel->setState('filter.published', 1);
     $listModel->setState('filter.showhidden', 0);
-    $listModel->setState('filter.showempty', 0);
+    $listModel->setState('filter.showempty', 1);
 
     if(Multilanguage::isEnabled())
     {


### PR DESCRIPTION
Currently, only (sub)categories that contain images are displayed in the category view.
This PR ensures that empty categories are also displayed.