### PR TITLE
Frontend category view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /administrator/com_joomgallery/joomgallery.xml
 /administrator/com_joomgallery/joomgallery_old.xml
 node_modules
+joomgallery_old.xml

--- a/administrator/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
@@ -54,7 +54,10 @@ $classToggle = $isBtnGroup ? 'btn-check' : 'form-check-input';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
 $blockStart  = $isBtnGroup ? '' : '<div class="form-check">';
 $blockEnd    = $isBtnGroup ? '' : '</div>';
-$configName  = explode('__', $id)[1];
+
+// Catch config name from form field name
+$configName_arr = explode('jg_', $name);
+$configName = preg_split('/[!"`#%&.,:;<>=@{}~\$\(\)\*\+\/\\\?\[\]\^\|]+/', end($configName_arr))[0];
 
 // Add the attributes of the fieldset in an array
 $containerClass = trim($class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : ''));

--- a/administrator/com_joomgallery/layouts/joomla/pagination/link.php
+++ b/administrator/com_joomgallery/layouts/joomla/pagination/link.php
@@ -1,0 +1,94 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                              **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+******************************************************************************************/
+
+// No direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
+$item       = $displayData['data'];
+$display    = $item->text;
+$app        = Factory::getApplication();
+$span_class = '';
+
+switch ((string) $item->text) {
+    // Check for "Start" item
+    case Text::_('JLIB_HTML_START'):
+        $icon = $app->getLanguage()->isRtl() ? 'icon-angle-double-right' : 'icon-angle-double-left';
+        $aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
+        break;
+
+    // Check for "Prev" item
+    case $item->text === Text::_('JPREV'):
+        $item->text = Text::_('JPREVIOUS');
+        $icon = $app->getLanguage()->isRtl() ? 'icon-angle-right' : 'icon-angle-left';
+        $aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
+        $span_class = ' previous';
+        break;
+
+    // Check for "Next" item
+    case Text::_('JNEXT'):
+        $icon = $app->getLanguage()->isRtl() ? 'icon-angle-left' : 'icon-angle-right';
+        $aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
+        $span_class = ' next';
+        break;
+
+    // Check for "End" item
+    case Text::_('JLIB_HTML_END'):
+        $icon = $app->getLanguage()->isRtl() ? 'icon-angle-double-left' : 'icon-angle-double-right';
+        $aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
+        break;
+
+    default:
+        $icon = null;
+        $aria = Text::sprintf('JLIB_HTML_GOTO_PAGE', strtolower($item->text));
+        break;
+}
+
+if ($icon !== null) {
+    $display = '<span class="' . $icon . '" aria-hidden="true"></span>';
+}
+
+if ($displayData['active']) {
+    if ($item->base > 0) {
+        $limit = 'limitstart.value=' . $item->base;
+    } else {
+        $limit = 'limitstart.value=0';
+    }
+
+    $class = 'active';
+
+    if ($app->isClient('administrator')) {
+        $link = 'href="#" onclick="document.adminForm.' . $item->prefix . $limit . '; Joomla.submitform();return false;"';
+    } elseif ($app->isClient('site')) {
+        $link = 'href="' . $item->link . '"';
+    }
+} else {
+    $class = (property_exists($item, 'active') && $item->active) ? 'active' : 'disabled';
+}
+
+?>
+<?php if ($displayData['active']) : ?>
+    <li class="page-item">
+        <a aria-label="<?php echo $aria; ?>" <?php echo $link; ?> class="page-link<?php echo $span_class; ?>">
+            <?php echo $display; ?>
+        </a>
+    </li>
+<?php elseif (isset($item->active) && $item->active) : ?>
+    <?php $aria = Text::sprintf('JLIB_HTML_PAGE_CURRENT', strtolower($item->text)); ?>
+    <li class="<?php echo $class; ?> page-item">
+        <a aria-current="true" aria-label="<?php echo $aria; ?>" href="#" class="page-link<?php echo $span_class; ?>"><?php echo $display; ?></a>
+    </li>
+<?php else : ?>
+    <li class="<?php echo $class; ?> page-item">
+        <span class="page-link<?php echo $span_class; ?>" aria-hidden="true"><?php echo $display; ?></span>
+    </li>
+<?php endif; ?>

--- a/administrator/com_joomgallery/layouts/joomla/pagination/links.php
+++ b/administrator/com_joomgallery/layouts/joomla/pagination/links.php
@@ -1,0 +1,88 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                              **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+******************************************************************************************/
+
+// No direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
+use Joomla\CMS\Layout\LayoutHelper;
+
+$list  = $displayData['list'];
+$pages = $list['pages'];
+
+$options = new Registry($displayData['options']);
+
+$showLimitBox   = $options->get('showLimitBox', false);
+$showPagesLinks = $options->get('showPagesLinks', true);
+$showLimitStart = $options->get('showLimitStart', true);
+
+// Calculate to display range of pages
+$currentPage = 1;
+$range       = 1;
+$step        = 5;
+
+if(!empty($pages['pages']))
+{
+  foreach($pages['pages'] as $k => $page)
+  {
+    if(!$page['active'])
+    {
+      $currentPage = $k;
+    }
+  }
+}
+
+if($currentPage >= $step)
+{
+  if($currentPage % $step === 0)
+  {
+    $range = ceil($currentPage / $step) + 1;
+  }
+  else
+  {
+    $range = ceil($currentPage / $step);
+  }
+}
+?>
+
+<?php if (!empty($pages)) : ?>
+  <nav class="pagination__wrapper" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
+    <div class="pagination pagination-toolbar text-center">
+      <?php if ($showLimitBox) : ?>
+        <div class="limit float-end">
+          <?php echo Text::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield']; ?>
+        </div>
+      <?php endif; ?>
+
+      <?php if ($showPagesLinks) : ?>
+        <ul class="pagination">
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
+          <?php foreach ($pages['pages'] as $k => $page) : ?>
+            <?php $output = LayoutHelper::render('joomla.pagination.link', $page); ?>
+            <?php if (in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
+              <?php if (($k % $step === 0 || $k === $range * $step - ($step + 1)) && $k !== $currentPage && $k !== $range * $step - $step) : ?>
+                <?php $output = preg_replace('#(<a.*?>).*?(</a>)#', '$1...$2', $output); ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php echo $output; ?>
+          <?php endforeach; ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['next']); ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
+        </ul>
+      <?php endif; ?>
+
+      <?php if ($showLimitStart) : ?>
+          <input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>">
+      <?php endif; ?>
+    </div>
+  </nav>
+<?php endif; ?>

--- a/joomgallery.xml
+++ b/joomgallery.xml
@@ -32,6 +32,7 @@
     <files folder="site/com_joomgallery">
         <folder>forms</folder>
         <folder>language</folder>
+        <folder>layouts</folder>
         <folder>src</folder>
         <folder>tmpl</folder>
     </files>

--- a/media/com_joomgallery/css/site.css
+++ b/media/com_joomgallery/css/site.css
@@ -21,6 +21,16 @@
 }
 
 /* List view */
+.js-stools-container-bar.flex-start .btn-toolbar {
+  justify-content: flex-start;
+}
+.js-stools-container-bar.flex-end .btn-toolbar {
+  justify-content: flex-end;
+}
+.pagination-toolbar.text-center {
+  text-align: center !important;
+  justify-content: center;
+}
 .jg_minithumb {
   border: 0;
   height: 80px;

--- a/site/com_joomgallery/layouts/joomla/pagination/link.php
+++ b/site/com_joomgallery/layouts/joomla/pagination/link.php
@@ -11,5 +11,5 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$path = JPATH_ADMINISTRATOR . '/components/com_joomgallery/layouts/joomla/pagination/links.php';
+$path = JPATH_ADMINISTRATOR . '/components/com_joomgallery/layouts/joomla/pagination/link.php';
 require($path);

--- a/site/com_joomgallery/layouts/joomla/pagination/links.php
+++ b/site/com_joomgallery/layouts/joomla/pagination/links.php
@@ -1,0 +1,88 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                              **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+******************************************************************************************/
+
+// No direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
+use Joomla\CMS\Layout\LayoutHelper;
+
+$list  = $displayData['list'];
+$pages = $list['pages'];
+
+$options = new Registry($displayData['options']);
+
+$showLimitBox   = $options->get('showLimitBox', false);
+$showPagesLinks = $options->get('showPagesLinks', true);
+$showLimitStart = $options->get('showLimitStart', true);
+
+// Calculate to display range of pages
+$currentPage = 1;
+$range       = 1;
+$step        = 5;
+
+if(!empty($pages['pages']))
+{
+  foreach($pages['pages'] as $k => $page)
+  {
+    if(!$page['active'])
+    {
+      $currentPage = $k;
+    }
+  }
+}
+
+if($currentPage >= $step)
+{
+  if($currentPage % $step === 0)
+  {
+    $range = ceil($currentPage / $step) + 1;
+  }
+  else
+  {
+    $range = ceil($currentPage / $step);
+  }
+}
+?>
+
+<?php if (!empty($pages)) : ?>
+  <nav class="pagination__wrapper" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
+    <div class="pagination pagination-toolbar text-center">
+      <?php if ($showLimitBox) : ?>
+        <div class="limit float-end">
+          <?php echo Text::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield']; ?>
+        </div>
+      <?php endif; ?>
+
+      <?php if ($showPagesLinks) : ?>
+        <ul class="pagination">
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
+          <?php foreach ($pages['pages'] as $k => $page) : ?>
+            <?php $output = LayoutHelper::render('joomla.pagination.link', $page); ?>
+            <?php if (in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
+              <?php if (($k % $step === 0 || $k === $range * $step - ($step + 1)) && $k !== $currentPage && $k !== $range * $step - $step) : ?>
+                <?php $output = preg_replace('#(<a.*?>).*?(</a>)#', '$1...$2', $output); ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php echo $output; ?>
+          <?php endforeach; ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['next']); ?>
+          <?php echo LayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
+        </ul>
+      <?php endif; ?>
+
+      <?php if ($showLimitStart) : ?>
+          <input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>">
+      <?php endif; ?>
+    </div>
+  </nav>
+<?php endif; ?>

--- a/site/com_joomgallery/layouts/joomla/searchtools/default.php
+++ b/site/com_joomgallery/layouts/joomla/searchtools/default.php
@@ -1,0 +1,120 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                              **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+******************************************************************************************/
+
+// No direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+$data = $displayData;
+
+// Receive overridable options
+$data['options'] = !empty($data['options']) ? $data['options'] : [];
+
+$noResultsText     = '';
+$hideActiveFilters = false;
+$showFilterButton  = false;
+$showSelector      = false;
+$selectorFieldName = $data['options']['selectorFieldName'] ?? 'client_id';
+
+// If a filter form exists.
+if(isset($data['view']->filterForm) && !empty($data['view']->filterForm))
+{
+  // Checks if a selector (e.g. client_id) exists.
+  if($selectorField = $data['view']->filterForm->getField($selectorFieldName))
+  {
+    $showSelector = $selectorField->getAttribute('filtermode', '') === 'selector' ? true : $showSelector;
+
+    // Checks if a selector should be shown in the current layout.
+    if(isset($data['view']->layout))
+    {
+      $showSelector = $selectorField->getAttribute('layout', 'default') != $data['view']->layout ? false : $showSelector;
+    }
+
+    // Unset the selector field from active filters group.
+    unset($data['view']->activeFilters[$selectorFieldName]);
+  }
+
+  // Checks if the filters button should exist.
+  $filters = $data['view']->filterForm->getGroup('filter');
+  $showFilterButton = isset($filters['filter_search']) && count($filters) === 1 ? false : true;
+
+  // Checks if it should show the be hidden.
+  $hideActiveFilters = empty($data['view']->activeFilters);
+
+  // Check if the no results message should appear.
+  if(isset($data['view']->total) && (int) $data['view']->total === 0)
+  {
+    $noResults = $data['view']->filterForm->getFieldAttribute('search', 'noresults', '', 'filter');
+
+    if(!empty($noResults))
+    {
+      $noResultsText = Text::_($noResults);
+    }
+  }
+}
+
+// Set some basic options.
+$customOptions = [
+    'filtersHidden'       => isset($data['options']['filtersHidden']) && $data['options']['filtersHidden'] ? $data['options']['filtersHidden'] : $hideActiveFilters,
+    'filterButton'        => isset($data['options']['filterButton']) && $data['options']['filterButton'] ? $data['options']['filterButton'] : $showFilterButton,
+    'defaultLimit'        => $data['options']['defaultLimit'] ?? Factory::getApplication()->get('list_limit', 20),
+    'searchFieldSelector' => '#filter_search',
+    'selectorFieldName'   => $selectorFieldName,
+    'selectorClass'       => '',
+    'showSelector'        => $showSelector,
+    'orderFieldSelector'  => '#list_fullordering',
+    'showNoResults'       => !empty($noResultsText),
+    'noResultsText'       => !empty($noResultsText) ? $noResultsText : '',
+    'formSelector'        => !empty($data['options']['formSelector']) ? $data['options']['formSelector'] : '#adminForm',
+    'barClass'            => '',
+    'showSearch'          => true,
+    'showList'            => true
+];
+
+// Merge custom options in the options array.
+$data['options'] = array_merge($customOptions, $data['options']);
+
+// Add class to hide the active filters if needed.
+$filtersActiveClass = $hideActiveFilters ? '' : ' js-stools-container-filters-visible';
+
+// Load search tools
+HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['options']);
+?>
+<div class="js-stools" role="search">
+  <?php if ($data['options']['showSelector']) : ?>
+  <div class="js-stools-container-selector <?php echo $data['options']['selectorClass'];?>">
+    <?php echo $this->sublayout('selector', $data); ?>
+  </div>
+  <?php endif; ?>
+  <div class="js-stools-container-bar <?php echo $data['options']['barClass'];?>">
+    <div class="btn-toolbar">
+      <?php if ($data['options']['showSearch']) : ?>
+        <?php echo $this->sublayout('bar', $data); ?>
+      <?php endif; ?>
+      <?php if ($data['options']['showList']) : ?>
+        <?php echo $this->sublayout('list', $data); ?>
+      <?php endif; ?>
+    </div>
+  </div>
+
+  <!-- Filters div -->
+  <?php if ($data['options']['filterButton']) : ?>
+    <div class="js-stools-container-filters clearfix<?php echo $filtersActiveClass; ?>">
+      <?php echo $this->sublayout('filters', $data); ?>
+    </div>
+  <?php endif; ?>
+</div>
+
+<?php if ($data['options']['showNoResults']) : ?>
+  <?php echo $this->sublayout('noitems', $data); ?>
+<?php endif; ?>

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -144,7 +144,7 @@ class CategoryModel extends JoomItemModel
     }
 
     // Load categories list model
-    $listModel = $this->component->getMVCFactory()->createModel('categories', 'administrator');
+    $listModel = $this->component->getMVCFactory()->createModel('categories', 'site');
     $listModel->getState();
     
     // Select fields to load
@@ -184,6 +184,66 @@ class CategoryModel extends JoomItemModel
   }
 
   /**
+   * Method to get a \JPagination object for the children categories.
+   *
+   * @return  Pagination  A Pagination object for the children categories.
+   */
+  public function getChildrenPagination()
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('categories', 'administrator');
+    $listModel->getState();
+
+    return $listModel->getPagination();
+  }
+
+  /**
+   * Get the filter form for the children categories.
+   *
+   * @param   array    $data      data
+   * @param   boolean  $loadData  load current data
+   *
+   * @return  Form|null  The \JForm object or null if the form can't be found
+   */
+  public function getChildrenFilterForm($data = [], $loadData = true)
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('categories', 'site');
+    $listModel->getState();
+
+    return $listModel->getFilterForm($data, $loadData);
+  }
+
+  /**
+   * Function to get the active filters for the children categories.
+   *
+   * @return  array  Associative array in the format: array('filter_published' => 0)
+   */
+  public function getChildrenActiveFilters()
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('categories', 'site');
+    $listModel->getState();
+
+    return $listModel->getActiveFilters();
+  }
+
+  /**
 	 * Method to get the images in this category.
 	 *
 	 * @return  array|false    Array of images on success, false on failure.
@@ -198,7 +258,7 @@ class CategoryModel extends JoomItemModel
     }
 
     // Load images list model
-    $listModel = $this->component->getMVCFactory()->createModel('images', 'administrator');
+    $listModel = $this->component->getMVCFactory()->createModel('images', 'site');
     $listModel->getState();
 
     // Select fields to load
@@ -233,6 +293,66 @@ class CategoryModel extends JoomItemModel
     }
 
     return $items;
+  }
+
+  /**
+   * Method to get a \JPagination object for the images in this category.
+   *
+   * @return  Pagination  A Pagination object for the images in this category.
+   */
+  public function getImagesPagination()
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('images', 'site');
+    $listModel->getState();
+
+    return $listModel->getPagination();
+  }
+
+  /**
+   * Get the filter form for the images in this category.
+   *
+   * @param   array    $data      data
+   * @param   boolean  $loadData  load current data
+   *
+   * @return  Form|null  The \JForm object or null if the form can't be found
+   */
+  public function getImagesFilterForm($data = [], $loadData = true)
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('images', 'site');
+    $listModel->getState();
+
+    return $listModel->getFilterForm($data, $loadData);
+  }
+
+  /**
+   * Function to get the active filters for the images in this category.
+   *
+   * @return  array  Associative array in the format: array('filter_published' => 0)
+   */
+  public function getImagesActiveFilters()
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load categories list model
+    $listModel = $this->component->getMVCFactory()->createModel('images', 'site');
+    $listModel->getState();
+
+    return $listModel->getActiveFilters();
   }
 
   /**

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -130,6 +130,29 @@ class CategoryModel extends JoomItemModel
 	}
 
   /**
+	 * Method to get the parent category item object.
+	 *
+	 * @param   integer  $id   The id of the object to get.
+	 *
+	 * @return  mixed    Object on success, false on failure.
+	 *
+	 * @throws \Exception
+	 */
+  public function getParent($id = null)
+  {
+    if($this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+    // Load parent category model
+    $parentModel = $this->component->getMVCFactory()->createModel('category', 'site');
+    $parentModel->getState();
+
+    return $parentModel->getItem($this->item->parent_id);
+  }
+
+  /**
 	 * Method to get the children categories.
 	 *
 	 * @return  array|false    Array of children on success, false on failure.

--- a/site/com_joomgallery/src/View/Category/HtmlView.php
+++ b/site/com_joomgallery/src/View/Category/HtmlView.php
@@ -14,10 +14,10 @@ namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 // No direct access
 defined('_JEXEC') or die;
 
-use \Joomla\CMS\MVC\View\GenericDataException;
-use \Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
+use \Joomla\CMS\MVC\View\GenericDataException;
+use \Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 
 /**
  * View class for a category view of Joomgallery.
@@ -30,9 +30,16 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The category object
 	 *
-	 * @var  \stdClass
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $item;
+
+  /**
+	 * The active menu item object
+	 *
+	 * @var  \Joomla\CMS\Menu\MenuItem
+	 */
+	protected $menu;
 
 	/**
 	 * The page parameters
@@ -67,10 +74,12 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
+    // Current category item
 		$this->state  = $this->get('State');
 		$this->params = $this->get('Params');
 		$this->acl    = $this->get('Acl');
 		$this->item   = $this->get('Item');
+    $this->menu   = Factory::getApplication()->getMenu()->getActive();
 
 		// Check acces view level
 		if(!in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
@@ -79,10 +88,18 @@ class HtmlView extends BaseHtmlView
     }
 
     // Load subcategories
-    $this->item->children = $this->get('Children');
+    $this->item->children = new \stdClass();
+    $this->item->children->items         = $this->get('Children');
+    //$this->item->children->pagination    = $this->get('ChildrenPagination');
+		//$this->item->children->filterForm    = $this->get('ChildrenFilterForm');
+		//$this->item->children->activeFilters = $this->get('ChildrenActiveFilters');
 
     // Load images
-    $this->item->images = $this->get('Images');
+    $this->item->images = new \stdClass();
+    $this->item->images->items         = $this->get('Images');
+    $this->item->images->pagination    = $this->get('ImagesPagination');
+		$this->item->images->filterForm    = $this->get('ImagesFilterForm');
+		$this->item->images->activeFilters = $this->get('ImagesActiveFilters');
 
     // Check for errors.
 		if(count($errors = $this->get('Errors')))
@@ -105,16 +122,13 @@ class HtmlView extends BaseHtmlView
 	protected function _prepareDocument()
 	{
 		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
 		$title = null;
 
 		// Because the application sets a default page title,
 		// We need to get it from the menu item itself
-		$menu = $menus->getActive();
-
-		if($menu)
+		if($this->menu)
 		{
-			$this->params['menu']->def('page_heading', $this->params['menu']->get('page_title', $menu->title));
+			$this->params['menu']->def('page_heading', $this->params['menu']->get('page_title', $this->menu->title));
 		}
 		else
 		{

--- a/site/com_joomgallery/src/View/Category/HtmlView.php
+++ b/site/com_joomgallery/src/View/Category/HtmlView.php
@@ -87,12 +87,12 @@ class HtmlView extends BaseHtmlView
       Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
     }
 
+    // Load parent category
+    $this->item->parent = $this->get('Parent');
+
     // Load subcategories
     $this->item->children = new \stdClass();
-    $this->item->children->items         = $this->get('Children');
-    //$this->item->children->pagination    = $this->get('ChildrenPagination');
-		//$this->item->children->filterForm    = $this->get('ChildrenFilterForm');
-		//$this->item->children->activeFilters = $this->get('ChildrenActiveFilters');
+    $this->item->children->items = $this->get('Children');
 
     // Load images
     $this->item->images = new \stdClass();

--- a/site/com_joomgallery/tmpl/category/default.php
+++ b/site/com_joomgallery/tmpl/category/default.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Router\Route;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Session\Session;
 use \Joomla\CMS\HTML\HTMLHelper;
+use \Joomla\CMS\Layout\LayoutHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 
 $category_class   = $this->params['menu']->get('jg_category_view_class', 'masonry', 'STRING');;
@@ -100,12 +101,12 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 
 <p><?php echo nl2br($this->item->description); ?></p>
 
-<?php if(count($this->item->children) == 0 && count($this->item->images) == 0) : ?>
+<?php if(count($this->item->children->items) == 0 && count($this->item->images->items) == 0) : ?>
   <p><?php echo Text::_('No elements in this category...') ?></p>
 <?php endif; ?>
 
 <?php // Subcategories ?>
-<?php if(count($this->item->children) > 0) : ?>
+<?php if(count($this->item->children->items) > 0) : ?>
   <?php if($this->item->parent_id > 0) : ?>
     <h3><?php echo Text::_('COM_JOOMGALLERY_SUBCATEGORIES') ?></h3>
   <?php else : ?>
@@ -116,7 +117,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <div id="jg-loader"></div>
   <?php endif; ?>
     <div class="jg-images <?php echo $category_class; ?>-<?php echo $num_columns; ?> jg-subcategories" data-masonry="{ pollDuration: 175 }">
-      <?php foreach($this->item->children as $key => $subcat) : ?>
+      <?php foreach($this->item->children->items as $key => $subcat) : ?>
         <div class="jg-image">
           <div class="jg-image-thumbnail<?php if(!empty($image_class) && $category_class != 'justified') : ?><?php echo ' ' . $image_class; ?><?php endif; ?>">
             <a href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $subcat->id); ?>">
@@ -142,12 +143,28 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php endif; ?>
 
 <?php // Images ?>
-<?php if(count($this->item->images) > 0) : ?>
+<?php if(count($this->item->images->items) > 0) : ?>
   <h3>Images</h3>
+  <?php if(!empty($this->item->images->filterForm)) : ?>
+    <?php // Show image filters ?>
+    <form action="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.$this->item->id.'&Itemid='.$this->menu->id.'&limitstart=0'); ?>" method="post" name="adminForm" id="adminForm">
+    <?php
+      {
+        echo LayoutHelper::render('joomla.searchtools.default', array(
+          'view' => $this->item->images, 
+          'options' => array('showSelector' => false, 'filterButton' => false, 'showNoResults' => false, 'showSearch' => false, 'barClass' => 'flex-end')
+        ));
+      }
+    ?>
+    <input type="hidden" name="task" value=""/>
+    <input type="hidden" name="filter_order" value=""/>
+    <input type="hidden" name="filter_order_Dir" value=""/>
+    <?php echo HTMLHelper::_('form.token'); ?>
+  <?php endif; ?>
   <div class="jg-gallery" itemscope="" itemtype="https://schema.org/ImageGallery">
-  <div id="jg-loader"></div>
+    <div id="jg-loader"></div>
     <div class="jg-images <?php echo $category_class; ?>-<?php echo $num_columns; ?> jg-category" data-masonry="{ pollDuration: 175 }">
-      <?php foreach($this->item->images as $key => $image) : ?>
+      <?php foreach($this->item->images->items as $key => $image) : ?>
         <div class="jg-image">
           <div class="jg-image-thumbnail<?php if(!empty($image_class) && $category_class != 'justified') : ?><?php echo ' ' . $image_class; ?><?php endif; ?>">
             <a href="<?php echo Route::_('index.php?option=com_joomgallery&view=image&id='.(int) $image->id); ?>">
@@ -170,6 +187,10 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
       <?php endforeach; ?>
     </div>
   </div>
+  <?php
+    // Show images pagination
+    echo $this->item->images->pagination->getListFooter();
+  ?>
 <?php endif; ?>
 
 <?php /*if($canAddImg) : ?>
@@ -195,7 +216,7 @@ function fadeImg () {
 </script>
 <?php endif; ?>
 
-<?php if(count($this->item->children) > 0 && $category_class == 'justified') : ?>
+<?php if(count($this->item->children->items) > 0 && $category_class == 'justified') : ?>
 <script>
 window.addEventListener('load', function () {
   const container = document.querySelector('.jg-subcategories');

--- a/site/com_joomgallery/tmpl/category/default.php
+++ b/site/com_joomgallery/tmpl/category/default.php
@@ -148,18 +148,19 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <?php if(!empty($this->item->images->filterForm)) : ?>
     <?php // Show image filters ?>
     <form action="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.$this->item->id.'&Itemid='.$this->menu->id.'&limitstart=0'); ?>" method="post" name="adminForm" id="adminForm">
-    <?php
-      {
-        echo LayoutHelper::render('joomla.searchtools.default', array(
-          'view' => $this->item->images, 
-          'options' => array('showSelector' => false, 'filterButton' => false, 'showNoResults' => false, 'showSearch' => false, 'barClass' => 'flex-end')
-        ));
-      }
-    ?>
-    <input type="hidden" name="task" value=""/>
-    <input type="hidden" name="filter_order" value=""/>
-    <input type="hidden" name="filter_order_Dir" value=""/>
-    <?php echo HTMLHelper::_('form.token'); ?>
+      <?php
+        {
+          echo LayoutHelper::render('joomla.searchtools.default', array(
+            'view' => $this->item->images, 
+            'options' => array('showSelector' => false, 'filterButton' => false, 'showNoResults' => false, 'showSearch' => false, 'barClass' => 'flex-end')
+          ));
+        }
+      ?>
+      <input type="hidden" name="task" value=""/>
+      <input type="hidden" name="filter_order" value=""/>
+      <input type="hidden" name="filter_order_Dir" value=""/>
+      <?php echo HTMLHelper::_('form.token'); ?>
+    </form>
   <?php endif; ?>
   <div class="jg-gallery" itemscope="" itemtype="https://schema.org/ImageGallery">
     <div id="jg-loader"></div>


### PR DESCRIPTION
Extending the frontend category view.

![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/2bb89585-0eed-47ad-9ad5-78c0aa523da1)

`$this->item->parent`
Item object of the parent category. Information about the parent category.

`$this->item->children`
List of subcategory item objects. Information about the subcategories.

`$this->item->images`
List of image item objects of this category. Including pagination and filter objects to create a pagination and a filter form. 

### How to test
Visit `index.php?option=com_joomgallery&view=category` (category view) in the frontend. There is now a filter form on top of the image grid and a pagination below.
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/7c99724e-a9bd-4ac5-a75d-9f01b83cb141)
