### PR TITLE
Fix wrong version info

### DIFF
--- a/administrator/com_joomgallery/src/View/Control/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Control/HtmlView.php
@@ -200,6 +200,7 @@ protected function getGalleryInfoData()
   $query = $db->getQuery(true)
               ->select($db->quoteName('manifest_cache'))
               ->from($db->quoteName('#__extensions'))
+              ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
               ->where($db->quoteName('element') . ' = ' . $db->quote('com_joomgallery'));
   $db->setQuery($query);
 

--- a/joomgallery.xml
+++ b/joomgallery.xml
@@ -80,7 +80,6 @@
         <plugin group="privacy" plugin="joomgalleryimages"/>
         <plugin group="webservices" plugin="joomgallery"/>
         <plugin group="finder" plugin="joomgallerycategories"/>
-        <plugin group="webservices" plugin="joomgallery"/>
     </plugins>
 
     <updateservers>


### PR DESCRIPTION
Under certain circumstances, the version info of the gallery is displayed incorrectly in the control panel.
This PR fixes this rare problem.

It also removes a duplicate entry from the joomgallery.xml:
`<plugin group="webservices" plugin="joomgallery"/>`

There's not much to test.