### PR TITLE
Fix issue: Wrong paths when renaming a category 

### DIFF
--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -396,6 +396,14 @@ class CategoryModel extends JoomAdminModel
         // Trigger the before save event.
         $result = $app->triggerEvent($this->event_before_save, array($context, $table, $isNew, $data));
 
+        // Stop storing data if one of the plugins returns false
+        if(\in_array(false, $result, true))
+        {
+          $this->setError($table->getError());
+
+          return false;
+        }
+
         // Store the data.
         if(!$table->store())
         {
@@ -438,13 +446,6 @@ class CategoryModel extends JoomAdminModel
           $manager->copyCategory($source_id, $table->path);
         }
 
-        if(\in_array(false, $result, true))
-        {
-          $this->setError($table->getError());
-
-          return false;
-        }
-
         // Clean the cache.
         $this->cleanCache();
 
@@ -458,6 +459,7 @@ class CategoryModel extends JoomAdminModel
       return false;
     }
 
+    // Set state
     if(isset($table->$key))
     {
       $this->setState($this->getName() . '.id', $table->$key);
@@ -465,99 +467,13 @@ class CategoryModel extends JoomAdminModel
 
     $this->setState($this->getName() . '.new', $isNew);
 
+    // Create/update associations
     if($this->associationsContext && Associations::isEnabled() && !empty($data['associations']))
     {
-      $associations = $data['associations'];
-
-      // Unset any invalid associations
-      $associations = ArrayHelper::toInteger($associations);
-
-      // Unset any invalid associations
-      foreach($associations as $tag => $id)
-      {
-        if(!$id)
-        {
-          unset($associations[$tag]);
-        }
-      }
-
-      // Show a warning if the item isn't assigned to a language but we have associations.
-      if($associations && $table->language === '*')
-      {
-        $app->enqueueMessage(Text::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'), 'warning');
-      }
-
-      // Get associationskey for edited item
-      $db    = $this->getDbo();
-      $id    = (int) $table->$key;
-      $query = $db->getQuery(true)
-          ->select($db->quoteName('key'))
-          ->from($db->quoteName('#__associations'))
-          ->where($db->quoteName('context') . ' = :context')
-          ->where($db->quoteName('id') . ' = :id')
-          ->bind(':context', $this->associationsContext)
-          ->bind(':id', $id, ParameterType::INTEGER);
-      $db->setQuery($query);
-      $oldKey = $db->loadResult();
-
-      if($associations || $oldKey !== null)
-      {
-        // Deleting old associations for the associated items
-        $query = $db->getQuery(true)
-            ->delete($db->quoteName('#__associations'))
-            ->where($db->quoteName('context') . ' = :context')
-            ->bind(':context', $this->associationsContext);
-
-        $where = [];
-
-        if($associations)
-        {
-          $where[] = $db->quoteName('id') . ' IN (' . implode(',', $query->bindArray(array_values($associations))) . ')';
-        }
-
-        if($oldKey !== null)
-        {
-          $where[] = $db->quoteName('key') . ' = :oldKey';
-          $query->bind(':oldKey', $oldKey);
-        }
-
-        $query->extendWhere('AND', $where, 'OR');
-        $db->setQuery($query);
-        $db->execute();
-      }
-
-      // Adding self to the association
-      if($table->language !== '*')
-      {
-        $associations[$table->language] = (int) $table->$key;
-      }
-
-      if(\count($associations) > 1)
-      {
-        // Adding new association for these items
-        $key   = md5(json_encode($associations));
-        $query = $db->getQuery(true)
-            ->insert($db->quoteName('#__associations'))
-            ->columns(
-                [
-                  $db->quoteName('id'),
-                  $db->quoteName('context'),
-                  $db->quoteName('key'),
-                ]
-            );
-
-        foreach($associations as $id)
-        {
-          $query->values(
-            implode(',', $query->bindArray([$id, $this->associationsContext, $key], [ParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING]))
-          );
-        }
-
-        $db->setQuery($query);
-        $db->execute();
-      }
+      $this->createAssociations($table, $data['associations']);
     }
 
+    // Redirect to associations
     if($app->input->get('task') == 'editAssociations')
     {
       return $this->redirectToAssociations($data);

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -551,10 +551,13 @@ class ImageModel extends JoomAdminModel
 					$this->setError($this->component->getDebug(true));
           $uploader->rollback($table);
 
-          if($isNew || $isCopy)
+          if($isNew)
           {
-            // Delete already stored record since image creation failed
-
+            // Delete the already stored new record if image creation failed
+            if(!$table->delete($table->$key))
+            {
+              $this->component->setError($table->getError());
+            }
           }
 
 					return false;

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -591,13 +591,13 @@ class ImageModel extends JoomAdminModel
 		}
 		
 		// Output warning messages
-		if(\count($this->component->getWarning()) > 1)
+		if(\count($this->component->getWarning()) > 0)
 		{
 			$this->component->printWarning();
 		}
 
 		// Output debug data
-		if(\count($this->component->getDebug()) > 1)
+		if(\count($this->component->getDebug()) > 0)
 		{
 			$this->component->printDebug();
 		}

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -485,6 +485,18 @@ class ImageModel extends JoomAdminModel
       // Trigger the before save event.
 			$result = $app->triggerEvent($this->event_before_save, array($context, $table, $isNew, $data));
 
+      // Stop storing data if one of the plugins returns false
+			if(\in_array(false, $result, true))
+			{
+        if($imgUploaded)
+				{
+        	$uploader->rollback($table);
+				}
+				$this->setError($table->getError());
+
+				return false;
+			}
+
 			// Store the data.
 			if(!$table->store())
 			{
@@ -539,19 +551,14 @@ class ImageModel extends JoomAdminModel
 					$this->setError($this->component->getDebug(true));
           $uploader->rollback($table);
 
+          if($isNew || $isCopy)
+          {
+            // Delete already stored record since image creation failed
+
+          }
+
 					return false;
 				}
-			}
-
-			if(\in_array(false, $result, true))
-			{
-        if($imgUploaded)
-				{
-        	$uploader->rollback($table);
-				}
-				$this->setError($table->getError());
-
-				return false;
 			}
 
       // Handle ajax uploads
@@ -600,104 +607,10 @@ class ImageModel extends JoomAdminModel
 
 		$this->setState($this->getName() . '.new', $isNew);
 
-		// Create associations
+		// Create/update associations
 		if($this->associationsContext && Associations::isEnabled() && !empty($data['associations']))
 		{
-			$associations = $data['associations'];
-
-			// Unset any invalid associations
-			$associations = ArrayHelper::toInteger($associations);
-
-			// Unset any invalid associations
-			foreach($associations as $tag => $id)
-			{
-				if(!$id)
-				{
-					unset($associations[$tag]);
-				}
-			}
-
-			// Show a warning if the item isn't assigned to a language but we have associations.
-			if($associations && $table->language === '*')
-			{
-				$app->enqueueMessage(Text::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'),	'warning');
-			}
-
-			// Get associationskey for edited item
-			$db    = $this->getDbo();
-			$id    = (int) $table->$key;
-			$query = $db->getQuery(true)
-				->select($db->quoteName('key'))
-				->from($db->quoteName('#__associations'))
-				->where($db->quoteName('context') . ' = :context')
-				->where($db->quoteName('id') . ' = :id')
-				->bind(':context', $this->associationsContext)
-				->bind(':id', $id, ParameterType::INTEGER);
-			$db->setQuery($query);
-			$oldKey = $db->loadResult();
-
-			if($associations || $oldKey !== null)
-			{
-				// Deleting old associations for the associated items
-				$query = $db->getQuery(true)
-					->delete($db->quoteName('#__associations'))
-					->where($db->quoteName('context') . ' = :context')
-					->bind(':context', $this->associationsContext);
-
-				$where = [];
-
-				if($associations)
-				{
-					$where[] = $db->quoteName('id') . ' IN (' . implode(',', $query->bindArray(array_values($associations))) . ')';
-				}
-
-				if($oldKey !== null)
-				{
-					$where[] = $db->quoteName('key') . ' = :oldKey';
-					$query->bind(':oldKey', $oldKey);
-				}
-
-				$query->extendWhere('AND', $where, 'OR');
-				$db->setQuery($query);
-				$db->execute();
-			}
-
-			// Adding self to the association
-			if($table->language !== '*')
-			{
-				$associations[$table->language] = (int) $table->$key;
-			}
-
-			if(\count($associations) > 1)
-			{
-				// Adding new association for these items
-				$key   = md5(json_encode($associations));
-				$query = $db->getQuery(true)
-					->insert($db->quoteName('#__associations'))
-					->columns(
-						[
-							$db->quoteName('id'),
-							$db->quoteName('context'),
-							$db->quoteName('key'),
-						]
-					);
-
-				foreach($associations as $id)
-				{
-					$query->values(
-						implode(
-							',',
-							$query->bindArray(
-								[$id, $this->associationsContext, $key],
-								[ParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING]
-							)
-						)
-					);
-				}
-
-				$db->setQuery($query);
-				$db->execute();
-			}
+      $this->createAssociations($table, $data['associations']);			
 		}
 
 		// Redirect to associations

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -17,6 +17,8 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Table\Table;
 use \Joomla\Registry\Registry;
+use \Joomla\Utilities\ArrayHelper;
+use \Joomla\Database\ParameterType;
 use \Joomla\CMS\MVC\Model\AdminModel;
 use \Joomla\CMS\Language\Multilanguage;
 use \Joomla\CMS\Form\FormFactoryInterface;
@@ -232,4 +234,113 @@ abstract class JoomAdminModel extends AdminModel
 
 		parent::preprocessForm($form, $data, $group);
 	}
+
+  /**
+	 * Set or update associations.
+	 *
+   * @param   Table  &$table        Table object (with reference)
+	 * @param   array  $associations  List of associated ids
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+  protected function createAssociations(Table &$table, array $associations)
+  {
+    $key = $table->getKeyName();
+
+    // Unset any invalid associations
+    $associations = ArrayHelper::toInteger($associations);
+
+    // Unset any invalid associations
+    foreach($associations as $tag => $id)
+    {
+      if(!$id)
+      {
+        unset($associations[$tag]);
+      }
+    }
+
+    // Show a warning if the item isn't assigned to a language but we have associations.
+    if($associations && $table->language === '*')
+    {
+      Factory::getApplication()->enqueueMessage(Text::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'),	'warning');
+    }
+
+    // Get associationskey for edited item
+    $db    = $this->getDbo();
+    $id    = (int) $table->$key;
+    $query = $db->getQuery(true)
+      ->select($db->quoteName('key'))
+      ->from($db->quoteName('#__associations'))
+      ->where($db->quoteName('context') . ' = :context')
+      ->where($db->quoteName('id') . ' = :id')
+      ->bind(':context', $this->associationsContext)
+      ->bind(':id', $id, ParameterType::INTEGER);
+    $db->setQuery($query);
+    $oldKey = $db->loadResult();
+
+    if($associations || $oldKey !== null)
+    {
+      // Deleting old associations for the associated items
+      $query = $db->getQuery(true)
+        ->delete($db->quoteName('#__associations'))
+        ->where($db->quoteName('context') . ' = :context')
+        ->bind(':context', $this->associationsContext);
+
+      $where = [];
+
+      if($associations)
+      {
+        $where[] = $db->quoteName('id') . ' IN (' . implode(',', $query->bindArray(array_values($associations))) . ')';
+      }
+
+      if($oldKey !== null)
+      {
+        $where[] = $db->quoteName('key') . ' = :oldKey';
+        $query->bind(':oldKey', $oldKey);
+      }
+
+      $query->extendWhere('AND', $where, 'OR');
+      $db->setQuery($query);
+      $db->execute();
+    }
+
+    // Adding self to the association
+    if($table->language !== '*')
+    {
+      $associations[$table->language] = (int) $table->$key;
+    }
+
+    if(\count($associations) > 1)
+    {
+      // Adding new association for these items
+      $key   = md5(json_encode($associations));
+      $query = $db->getQuery(true)
+        ->insert($db->quoteName('#__associations'))
+        ->columns(
+          [
+            $db->quoteName('id'),
+            $db->quoteName('context'),
+            $db->quoteName('key'),
+          ]
+        );
+
+      foreach($associations as $id)
+      {
+        $query->values(
+          implode(
+            ',',
+            $query->bindArray(
+              [$id, $this->associationsContext, $key],
+              [ParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING]
+            )
+          )
+        );
+      }
+
+      $db->setQuery($query);
+      $db->execute();
+    }
+  }
 }

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -346,9 +346,9 @@ class CategoryTable extends Table implements VersionableTableInterface
 			}
 		}
 
-    // Check if path is correct
+    // Create new path based on alias and parent category
     $manager    = JoomHelper::getService('FileManager');
-    $this->path = $manager->getCatPath($this->id, false, $this->parent_id, $this->alias);
+    $this->path = $manager->getCatPath(0, false, $this->parent_id, $this->alias);
 
 		// Support for subform field params
 		if(is_array($this->params))


### PR DESCRIPTION
This is a fix for issue #153 .
When renaming a category (alias needs to change) the path is now correctly updated in the database.

This is also a fix for issue #157 .
When a category is copied, the folder content in the filesystem is no longer copied. Making it possible to perform further operations on the just created category through copying.