### PR TITLE
Fix php error when interrupt migration before step 1

### DIFF
--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -605,7 +605,7 @@ abstract class Migration implements MigrationInterface
       throw new \Exception('Taget has to be eighter "source" or "destination". Given: ' . $target, 1);
     }
 
-    if($target === 'destination' || $this->params->get('same_db'))
+    if($target === 'destination' || $this->params->get('same_db', 1))
     {
       $db        = Factory::getContainer()->get(DatabaseInterface::class);
       $dbPrefix  = $this->app->get('dbprefix');

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -113,7 +113,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
    */
   public function getSourceXML()
   {
-    if($this->params->get('same_joomla'))
+    if($this->params->get('same_joomla', 1))
     {
       $path = Path::clean(JPATH_ADMINISTRATOR . '/components/com_joomgallery/joomgallery_old.xml');
       $xml  = \simplexml_load_file($path);
@@ -212,7 +212,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
 
     // add suffix, if source tables are in the same db with *_old at the end
     $source_db_suffix = '';
-    if($this->params->get('same_db'))
+    if($this->params->get('same_db', 1))
     {
       $source_db_suffix = '_old';
     }


### PR DESCRIPTION
If you interrupt a migration before saving the migration configuration form the first time you get a php error because there are no params.
This PR adds default values when getting migration params to mitigate that: `$this->params->get('same_db', 1)`

### Test result before applying this PR
Interrupting before submission of the migration configuration will throw a php error

### Test result after applying this PR
No error is thrown