### PR TITLE
Database connection problems

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -767,6 +767,9 @@ COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_APPLYSTATE_SUCCESSFUL_0="Record of type 
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_APPLYSTATE_SUCCESSFUL_1="Record of type %s with id=%s successfully marked as successful"
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_APPLYSTATE_SUCCESSFUL_2="Record of type %s with id=%s successfully marked as pending"
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_APPLYSTATE_NOT_AVAILABLE="Record with id=%s not available. State can not be changed."
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_JOOMLA_PATH="The given Joomla! path does not exist. Based on your server the path should look something like this:<br />%s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DB_CREDENTIALS="The given database credentials are not correct. Error from the database driver:<br />%s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DB_PREFIX="No tables with the provided database tables prefix found."
 
 ;Menu
 COM_JOOMGALLERY_MENU_CATEGORY_VIEW_OPTIONS="Category View"

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -499,19 +499,19 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
         {
             if($errors[$i] instanceof \Exception)
             {
-              $this->component->setWarning($errors[$i]->getMessage());
+              $this->app->enqueueMessage($errors[$i]->getMessage(), 'warning');
             }
             else
             {
-              $this->component->setWarning($errors[$i]);
+              $this->app->enqueueMessage($errors[$i], 'warning');
             }
         }
 
         // Save the form data in the session.
         $this->app->setUserState($context . '.data', $data);
 
-        // Redirect back to the edit screen.
-        $this->setRedirect(Route::_('index.php?option=' . _JOOM_OPTION . '&view=migration', false));
+        // Redirect back to step 1, the form.
+        $this->setRedirect(Route::_('index.php?option=' . _JOOM_OPTION . '&view=migration&layout=step1', false));
 
         return false;
       }

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -1098,6 +1098,7 @@ abstract class Migration implements MigrationInterface
     catch (\Exception $msg)
     {
       $checks->addCheck($category, 'src_table_connect', true, Text::_('JLIB_FORM_VALUE_SESSION_DATABASE'), Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_TABLE_CONN_ERROR'));
+      return;
     }
 
     // Check required tables

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -54,7 +54,7 @@ abstract class Migration implements MigrationInterface
    * 
    * @since  4.0.0
    */
-  protected $src_db = true;
+  protected $src_db = null;
 
   /**
 	 * Storage for the migration info object.

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -48,6 +48,15 @@ abstract class Migration implements MigrationInterface
 	protected $params = null;
 
   /**
+   * Storage for the source database driver object.
+   *
+   * @var    DatabaseInterface
+   * 
+   * @since  4.0.0
+   */
+  protected $src_db = true;
+
+  /**
 	 * Storage for the migration info object.
 	 *
 	 * @var   object
@@ -607,15 +616,22 @@ abstract class Migration implements MigrationInterface
 
     if($target === 'destination' || $this->params->get('same_db', 1))
     {
+      // Get database driver of the current joomla application
       $db        = Factory::getContainer()->get(DatabaseInterface::class);
       $dbPrefix  = $this->app->get('dbprefix');
     }
     else
     {
-      $options   = array ('driver' => $this->params->get('dbtype'), 'host' => $this->params->get('dbhost'), 'user' => $this->params->get('dbuser'), 'password' => $this->params->get('dbpass'), 'database' => $this->params->get('dbname'), 'prefix' => $this->params->get('dbprefix'));
-      $dbFactory = new DatabaseFactory();
-      $db        = $dbFactory->getDriver($this->params->get('dbtype'), $options);
-      $dbPrefix  = $this->params->get('dbprefix');
+      // Get database driver for the source joomla database
+      if(\is_null($this->src_db))
+      {
+        $options      = array ('driver' => $this->params->get('dbtype'), 'host' => $this->params->get('dbhost'), 'user' => $this->params->get('dbuser'), 'password' => $this->params->get('dbpass'), 'database' => $this->params->get('dbname'), 'prefix' => $this->params->get('dbprefix'));
+        $dbFactory    = new DatabaseFactory();
+        $this->src_db = $dbFactory->getDriver($this->params->get('dbtype'), $options);
+      }
+
+      $dbPrefix = $this->params->get('dbprefix');
+      $db       = $this->src_db;
     }
 
     return array($db, $dbPrefix);


### PR DESCRIPTION
This PR fixes multiple issues reported in #201.
The following things are added/improved:

- Migration form validation for field `Joomla! path`. Checks, if the folder of the given path exists.
- Migration form validation for database fields. Checks, if a connection to the database is possible with the entered credentials.
- Fixes php error: in_array(): Argument 2 ($haystack) must be of type array, null given

Pendent:

- Migration precheck needs 20 connections to the database