### PR TITLE
Show categories without images

### DIFF
--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -424,7 +424,7 @@ class CategoryModel extends JoomItemModel
     $listModel->setState('filter.access', $user->getAuthorisedViewLevels());
     $listModel->setState('filter.published', 1);
     $listModel->setState('filter.showhidden', 0);
-    $listModel->setState('filter.showempty', 0);
+    $listModel->setState('filter.showempty', 1);
 
     if(Multilanguage::isEnabled())
     {


### PR DESCRIPTION
This is a redo of https://github.com/JoomGalleryfriends/JG4-dev/pull/169 but this has been cancelled (accidentally?).

Description: Currently, categories that only contain subcategories but no images are not displayed in the category view. 
But in my opinion, this should not be the case.
With this PR, empty subcategories are also displayed in the category view.