### PR TITLE
Update Error/Logging functionalities

### DIFF
--- a/administrator/com_joomgallery/src/Extension/MessageTrait.php
+++ b/administrator/com_joomgallery/src/Extension/MessageTrait.php
@@ -158,33 +158,6 @@ trait MessageTrait
   }
 
   /**
-   * Log a message
-   * 
-   * @param   string   $txt       The message for a new log entry.
-   * @param   integer  $priority  Message priority.
-   *
-   * @return  void
-   *
-   * @since   4.0.0
-  */
-  protected function addLog(string $txt, int $priority = 8, string $name = null)
-  {
-    if(\is_null($name) && \is_null($this->logName))
-    {
-      Log::add($txt, $priority, 'com_joomgallery');
-    }
-    else
-    {
-      if(\is_null($name))
-      {
-        $name = $this->logName;
-      }
-
-      Log::add($txt, $priority, 'com_joomgallery'.$name);
-    }
-  }
-
-  /**
    * Set a default logger to be used from now on
    * 
    * @param   string   $name   Name of the logger. Empty to use the default JoomGallery logger
@@ -197,6 +170,50 @@ trait MessageTrait
   {
     $this->addLogger($name);
     $this->logName = $name;
+  }
+
+  /**
+   * Log a message
+   * 
+   * @param   string   $txt       The message for a new log entry.
+   * @param   integer  $priority  Message priority.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  public function addLog(string $txt, int $priority = 8, string $name = null)
+  {
+    $this->addLogger($name);
+    
+    if(\is_null($name) && \is_null($this->logName))
+    {
+      Log::add($txt, $priority, 'com_joomgallery');
+    }
+    else
+    {
+      if(\is_null($name))
+      {
+        $name = $this->logName;
+      }
+
+      Log::add($txt, $priority, 'com_joomgallery.'.$name);
+    }
+  }
+
+  /**
+   * Log a message
+   * 
+   * @param   string   $txt       The message for a new log entry.
+   * @param   integer  $priority  Message priority.
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  public function setLog(string $txt, int $priority = 8, string $name = null)
+  {
+    return $this->addLog($txt, $priority, $name);
   }
 
   /**
@@ -224,6 +241,24 @@ trait MessageTrait
   }
 
   /**
+   * Add text to the debug information storage
+   *
+   * @param   string   $txt         Text to add to the debugoutput
+   * @param   bool     $new_line    True to add text to a new line (default: true)
+   * @param   bool     $margin_top  True to add an empty line in front (default: false)
+   * @param   bool     $log         True to add error message to logfile (default: false)
+   * @param   string   $name        Name of the logger to be used (default: null)
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  public function setDebug($txt, $new_line=true, $margin_top=false, $log=false, $name=null)
+  {
+    return $this->addDebug($txt, $new_line, $margin_top, $log, $name);
+  }
+
+  /**
    * Add text to the warnings storage
    *
    * @param   string   $txt         Text to add to the debugoutput
@@ -248,6 +283,49 @@ trait MessageTrait
   }
 
   /**
+   * Add text to the warnings storage
+   *
+   * @param   string   $txt         Text to add to the debugoutput
+   * @param   bool     $new_line    True to add text to a new line (default: true)
+   * @param   bool     $margin_top  True to add an empty line in front (default: false)
+   * @param   bool     $log         True to add error message to logfile (default: false)
+   * @param   string   $name        Name of the logger to be used (default: null)
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  public function setWarning($txt, $new_line=true, $margin_top=false, $log=false, $name=null)
+  {
+    return $this->addWarning($txt, $new_line, $margin_top, $log, $name);
+  }
+
+  /**
+   * Set error and add it to the error storage
+   *
+   * @param   string   $txt         Text to add to the error storage
+   * @param   bool     $new_line    True to add text to a new line (default: true)
+   * @param   bool     $margin_top  True to add an empty line in front (default: false)
+   * @param   bool     $log         True to add error message to logfile (default: true)
+   * @param   string   $name        Name of the logger to be used (default: null)
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  public function addError($txt, $new_line=true, $margin_top=false, $log=true, $name=null)
+  {
+    $this->setMsg($txt, 'error', $new_line, $margin_top);
+    $this->error = true;
+
+    if($log)
+    {
+      $this->addLogger($name);
+      $this->addLog($txt, Log::ERROR, $name);
+    }
+  }
+
+  /**
    * Set error and add it to the error storage
    *
    * @param   string   $txt         Text to add to the error storage
@@ -262,14 +340,7 @@ trait MessageTrait
   */
   public function setError($txt, $new_line=true, $margin_top=false, $log=true, $name=null)
   {
-    $this->setMsg($txt, 'error', $new_line, $margin_top);
-    $this->error = true;
-
-    if($log)
-    {
-      $this->addLogger($name);
-      $this->addLog($txt, Log::ERROR, $name);
-    }
+    return $this->addError($txt, $new_line, $margin_top, $log, $name);
   }
 
   /**


### PR DESCRIPTION
This PR fixes and improves the error and logging functionities provided by the JoomGallery extension class.
The following methods are available:

```
// Add debug message
setDebug($txt, $new_line=true, $margin_top=false, $log=false, $name=null)

// Add warning message
setWarning($txt, $new_line=true, $margin_top=false, $log=false, $name=null)

// Add error message
setError($txt, $new_line=true, $margin_top=false, $log=true, $name=null)

// Add a message to a logging file
setLog($txt, $priority = 8, $name = null)
```

With the argument `$log` you can activate to add also a logging entry. So the message will be outputted as well as logged. With `$name` you can choose the filename of the logging file where to output. The default file is `com_joomgallery.log.php`. If you add a logging name the file will look like `com_joomgallery.name.log.php`.

## How to test this PR

### Scenario 1 (manually set an error)
Edit a HtmlView.php file of your choice. Add the following line:

```
$this->component->setError('Your error message');
```

Activate "Debug System" in the Joomla global configuration. Access the view you edited. 

You should get the error message as a bootstrap alert box
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/6557f4cd-1b27-41c9-b55f-2c0624185eba)

Additionally you get the message in the Joomla internal debugging console
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/aece8541-13b7-4bbe-8204-2121f672e2d7)

And you should see a file in your Joomla log directory called `com_joomgallery.log.php` where you find the error message
![grafik](https://github.com/JoomGalleryfriends/JG4-dev/assets/39154009/1cd9555c-9535-4b1a-916c-eb7af7a20710)

### Scenario 2 (error during upload)
Upload two faulty images via the uppy uploader.
You should see a file in your Joomla log directory called `com_joomgallery.log.php` where you find the error message thrown from uploading the faulty images.

### Scenario 3 (error during migration)
Force an error during migration in step 3 of the migration manager.
You should see a file in your Joomla log directory called `com_joomgallery.log.php` where you find the error message thrown from uploading the faulty images.