### PR TITLE
Fix error when exec is disabled

### DIFF
--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -104,6 +104,17 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
    */
   public function version()
   {
+    // Check, if exec command is available
+    $disabled_functions = \explode(',', \ini_get('disable_functions'));
+
+    foreach($disabled_functions as $disabled_function)
+    {
+      if(trim($disabled_function) == 'exec')
+      {
+        return false;
+      }
+    }
+
     // Check availability and version of ImageMagick v7.x
     @\exec(\trim($this->impath).'magick -version', $output);
 
@@ -170,7 +181,8 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     $this->commands = array();
 
     // Check, if exec command is available
-    $disabled_functions = \explode(',', \ini_get('disabled_functions'));
+    $disabled_functions = \explode(',', \ini_get('disable_functions'));
+
     foreach($disabled_functions as $disabled_function)
     {
       if(\trim($disabled_function) == 'exec')
@@ -941,6 +953,17 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
    */
   public function getTypes(): array
   {
+    // Check, if exec command is available
+    $disabled_functions = \explode(',', \ini_get('disable_functions'));
+
+    foreach($disabled_functions as $disabled_function)
+    {
+      if(trim($disabled_function) == 'exec')
+      {
+        return array();
+      }
+    }
+
     // Get supported types of ImageMagick v7.x
     @\exec(\trim($this->impath).'magick -list format', $output);
 


### PR DESCRIPTION
This is a fix for issue https://github.com/JoomGalleryfriends/JG4-dev/issues/221
If the 'exec' function is deactivated on the server, an error occurs when the JoomGallery configuration is opened.

### How to test this PR

Add 'exec' to the list of disabled functions in php.ini:
`disable_functions="show_source, system, shell_exec, exec"`


### Test result before applying this PR

A PHP error occurs when opening the JoomGallery configuration.

### Test result after applying this PR

No error is thrown.