### PR TITLE
Add modalbox

### DIFF
--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/sectionWithPopup.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/sectionWithPopup.php
@@ -9,11 +9,16 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
+
+// Load bootstrap modal
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('bootstrap.modal');
 
 /**
  * Layout variables

--- a/administrator/com_joomgallery/tmpl/config/edit.php
+++ b/administrator/com_joomgallery/tmpl/config/edit.php
@@ -21,7 +21,8 @@ use \Joomla\CMS\Language\Text;
 HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
-	 ->useScript('form.validate');
+	 ->useScript('form.validate')
+   ->useScript('bootstrap.modal');
 HTMLHelper::_('bootstrap.tooltip');
 
 // Import CSS

--- a/administrator/com_joomgallery/tmpl/image/upload.php
+++ b/administrator/com_joomgallery/tmpl/image/upload.php
@@ -24,6 +24,7 @@ $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	 ->useScript('form.validate')
    ->useScript('com_joomgallery.uppy-uploader')
+   ->useScript('bootstrap.modal')
    ->useStyle('com_joomgallery.uppy')
    ->useStyle('com_joomgallery.admin');
 


### PR DESCRIPTION
Since Joomla 5.1.0 bootstrap.modal javascript library is not loaded automatically anymore. Therefore views using the bootstrap modalbox have to load the library by themselves.

The modalbox is added to the following views:
- Configuration set edit
- Multiple image upload form