### PR TITLE
Fix errors in system plugin

### DIFF
--- a/plugins/system/joomgallery/src/Extension/Joomgallery.php
+++ b/plugins/system/joomgallery/src/Extension/Joomgallery.php
@@ -198,9 +198,8 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
         break;
     }
 
-
     // Return the result
-		$this->setResult($event, true);
+		$this->setResult($event, true, false);
   }
 
   /**
@@ -215,7 +214,11 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
    */
   public function onContentPrepareForm(Event $event)
   {
-    [$form, $data] = $event->getArguments();
+    try
+    {
+      [$form, $data] = $event->getArguments();
+    } catch (\Throwable $th) { }
+    
     if(!$form)
     {
       // Joomla 5
@@ -261,7 +264,11 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
    */
   public function onContentPrepareData(Event $event)
   {
-    [$context, $data] = $event->getArguments();
+    try
+    {
+      [$context, $data] = $event->getArguments();
+    } catch (\Throwable $th) { }
+    
     if(!$context)
     {
       // Joomla 5
@@ -322,7 +329,11 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
    */
   public function onUserAfterSave(Event $event)
   { 
-    [$data, $isNew, $result, $error] = $event->getArguments();
+    try
+    {
+      [$data, $isNew, $result, $error] = $event->getArguments();
+    } catch (\Throwable $th) { }
+    
     if(!$data)
     {
       // Joomla 5
@@ -390,7 +401,11 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
    */
   public function onUserAfterDelete(Event $event)
   { 
-    [$data, $result, $error] = $event->getArguments();
+    try
+    {
+      [$data, $result, $error] = $event->getArguments();
+    } catch (\Throwable $th) { }
+    
     if(!$data)
     {
       // Joomla 5
@@ -522,12 +537,13 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
    *
    * @param   Event  $event  The event object
    * @param   mixed  $value  The value to be added to the result
+   * @param   bool   $array  True, if the reuslt has to be added/set to the result array. False to override the boolean result value.
    *
    * @return  void
    *
    * @since   4.0.0
    */
-  private function setResult(Event $event, $value): void
+  private function setResult(Event $event, $value, $array=true): void
 	{
 		if($event instanceof ResultAwareInterface)
     {
@@ -536,9 +552,18 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
 			return;
 		}
 
-		$result   = $event->getArgument('result', []) ?: [];
-		$result   = is_array($result) ? $result : [];
-		$result[] = $value;
+    if($array)
+    {
+      $result   = $event->getArgument('result', []) ?: [];
+		  $result   = is_array($result) ? $result : [];
+		  $result[] = $value;
+    }
+    else
+    {
+      $result   = $event->getArgument('result', true) ?: true;
+      $result   = ($result == false) ? false : $value;
+    }
+		
 		$event->setArgument('result', $result);
 	}
 

--- a/plugins/system/joomgallery/src/Extension/Joomgallery.php
+++ b/plugins/system/joomgallery/src/Extension/Joomgallery.php
@@ -145,7 +145,7 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
     if(\strpos($defaultgroup, 'com_joomgallery') !== 0 && \strpos($defaultgroup, 'com_users') !== 0 && \strpos($defaultgroup, 'com_menus') !== 0)
     {
       // Do nothing if we are not handling joomgallery content
-      $this->setResult($event, true);
+      $this->setResult($event, true, false);
 
       return;
     }
@@ -154,7 +154,7 @@ final class Joomgallery extends CMSPlugin implements SubscriberInterface
     if(!$type = $this->guessType($defaultgroup))
     {
       // Type not recognized. Do nothing.
-      $this->setResult($event, true);
+      $this->setResult($event, true, false);
 
       return;
     }


### PR DESCRIPTION
This PR fix es issues reported in #226 

There is an additional warning printed out in Joomla 5.x telling that `Undefined array key 0 in C:\Users\Manuel\Documents\GitHub\JG4-dev\plugins\system\joomgallery\src\Extension\Joomgallery.php on line 219`. This warning can  not be solved without loosing functionality in Joomla 4.x. Possible PHP errors in future PHP versions are catched and handled not to loose functionality.

### Reported Issue

```
Joomla\CMS\Event\Model\AfterCleanCacheEvent::onSetResult(): Argument https://github.com/JoomGalleryfriends/JG4-dev/pull/1 ($value) must be of type bool, array given, called in /joomla-root-verzeichnis/libraries/src/Event/AbstractEvent.php on line 227
```