### PR TITLE
Category password field

### DIFF
--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -71,9 +71,10 @@
 
     <field name="password"
            type="password"
-           size="100"
            label="JGLOBAL_PASSWORD"
-           description="COM_JOOMGALLERY_FIELDS_PASSWORD_DESC" />
+           description="COM_JOOMGALLERY_FIELDS_PASSWORD_DESC"
+           filter="raw"
+           strengthmeter="true" />
 
     <field name="language"
            type="language"

--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -79,6 +79,7 @@
     <field name="rm_password"
            type="radio"
            label="COM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_LABEL"
+           description="CCOM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_DESC"
            class="btn-group"
            default="0">
         <option value="0">JNO</option>

--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -73,7 +73,8 @@
            type="password"
            label="JGLOBAL_PASSWORD"
            description="COM_JOOMGALLERY_FIELDS_PASSWORD_DESC"
-           filter="raw" />
+           filter="raw"
+           strengthmeter="true" />
 
     <field name="rm_password"
            type="radio"

--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -73,8 +73,7 @@
            type="password"
            label="JGLOBAL_PASSWORD"
            description="COM_JOOMGALLERY_FIELDS_PASSWORD_DESC"
-           filter="raw"
-           strengthmeter="true" />
+           filter="raw" />
 
     <field name="rm_password"
            type="radio"

--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -76,6 +76,15 @@
            filter="raw"
            strengthmeter="true" />
 
+    <field name="rm_password"
+           type="radio"
+           label="COM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_LABEL"
+           class="btn-group"
+           default="0">
+        <option value="0">JNO</option>
+        <option value="1">JYES</option>
+    </field>
+
     <field name="language"
            type="language"
            client="administrator"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -393,6 +393,7 @@ COM_JOOMGALLERY_FIELDS_SRC_EXTENSION_LABEL="Source extension compatibility"
 COM_JOOMGALLERY_FIELDS_SOURCE_IDS_LABEL="Use source ID's"
 COM_JOOMGALLERY_FIELDS_SOURCE_IDS_DESC="If set to yes, the ID's of the source records are used to create the destination records.{tip}In order to use this option, the ID's from source must not exist in the destination datebase table. Tip: Make sure, the destination tables are empty."
 COM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_LABEL="Remove password"
+CCOM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_DESC="To remove an existing password, set 'Remove password' to 'yes' and save the category."
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Configuration inheritance"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -392,6 +392,7 @@ COM_JOOMGALLERY_FIELDS_DEST_EXTENSION_LABEL="Destination extension compatibility
 COM_JOOMGALLERY_FIELDS_SRC_EXTENSION_LABEL="Source extension compatibility"
 COM_JOOMGALLERY_FIELDS_SOURCE_IDS_LABEL="Use source ID's"
 COM_JOOMGALLERY_FIELDS_SOURCE_IDS_DESC="If set to yes, the ID's of the source records are used to create the destination records.{tip}In order to use this option, the ID's from source must not exist in the destination datebase table. Tip: Make sure, the destination tables are empty."
+COM_JOOMGALLERY_FIELDS_REMOVE_PASSWORD_LABEL="Remove password"
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_INHERITANCE_METHOD_LABEL="Configuration inheritance"

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -382,7 +382,19 @@ class CategoryModel extends JoomAdminModel
     if(\array_key_exists('tags', $data) && \is_array($data['tags']) && \count($data['tags']) > 0)
     {
       $table->newTags = $data['tags'];
-    }    
+    }
+
+    // Password
+    if(isset($data['rm_password']) && $data['rm_password'] == true)
+    {
+      $table->rm_pw = true;
+    }
+    elseif(isset($data['password']) && !empty($data['password']))
+    {
+      $table->new_pw = $data['password'];
+    }
+    unset($data['rm_password']);
+    unset($data['password']);
 
     // Change language to 'All' if multilangugae is not enabled
     if (!Multilanguage::isEnabled())

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -135,7 +135,7 @@ class CategoryModel extends JoomAdminModel
 			$data = $this->item;
 
       // Support for password field
-      if(isset($data->password) && empty($data->password))
+      if(\property_exists($data, 'password') && empty($data->password))
       {
         $this->is_password = false;
       }

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -36,6 +36,14 @@ class CategoryModel extends JoomAdminModel
    */
   protected $type = 'category';
 
+  /**
+   * True if a password is set
+   *
+   * @access  protected
+   * @var     bool
+   */
+  protected $is_password = true;
+
 	/**
 	 * Method to get the record form.
 	 *
@@ -73,6 +81,15 @@ class CategoryModel extends JoomAdminModel
 
 		// Apply filter for current category on thumbnail field
     $form->setFieldAttribute('thumbnail', 'categories', $id);
+
+    // Disable remove password field if no password is set
+    if(!$this->is_password)
+    {
+      $form->setFieldAttribute('rm_password', 'disabled', 'true');
+      $form->setFieldAttribute('rm_password', 'filter', 'unset');
+      $form->setFieldAttribute('rm_password', 'hidden', 'true');
+      $form->setFieldAttribute('rm_password', 'class', 'hidden');
+    }    
 
     // Modify the form based on Edit State access controls.
 		if(!$this->canEditState($record))
@@ -118,6 +135,10 @@ class CategoryModel extends JoomAdminModel
 			$data = $this->item;
 
       // Support for password field
+      if(isset($data->password) && empty($data->password))
+      {
+        $this->is_password = false;
+      }
       $data->password = '';
 
 			// Support for multiple or not foreign key field: robots

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -115,7 +115,10 @@ class CategoryModel extends JoomAdminModel
 				$this->item = $this->getItem();
 			}
 
-			$data = $this->item;			
+			$data = $this->item;
+
+      // Support for password field
+      $data->password = '';
 
 			// Support for multiple or not foreign key field: robots
 			$array = array();

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -241,13 +241,20 @@ class CategoryTable extends Table implements VersionableTableInterface
     // Support for password field
     if(isset($array['password']))
     {
-      if(!empty($array['password']))
+      if(isset($array['rm_password']) && $array['rm_password'] == true)
       {
-        $array['password'] = UserHelper::hashPassword($array['password']);
+        $array['password'] = '';
       }
       else
       {
-        unset($array['password']);
+        if(!empty($array['password']))
+        {
+          $array['password'] = UserHelper::hashPassword($array['password']);
+        }
+        else
+        {
+          unset($array['password']);
+        }
       }
     }
 

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -295,7 +295,7 @@ class CategoryTable extends Table implements VersionableTableInterface
     $this->setPathWithLocation();
 
     // Support for password field
-    if(isset($this->password))
+    if(\property_exists($this, 'password'))
     {
       if(\strlen($this->new_pw) > 0)
       {

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -52,6 +52,22 @@ class CategoryTable extends Table implements VersionableTableInterface
    */
   protected $_old_location_path = null;
 
+  /**
+   * Set here the new password
+   *
+   * @var    string
+   * @since  4.0.0
+   */
+  public $new_pw = '';
+
+  /**
+   * True, if you want to delete current password
+   *
+   * @var    bool
+   * @since  4.0.0
+   */
+  public $rm_pw = false;
+
 	/**
 	 * Constructor
 	 *
@@ -238,26 +254,6 @@ class CategoryTable extends Table implements VersionableTableInterface
       }
     }
 
-    // Support for password field
-    if(isset($array['password']))
-    {
-      if(isset($array['rm_password']) && $array['rm_password'] == true)
-      {
-        $array['password'] = '';
-      }
-      else
-      {
-        if(!empty($array['password']))
-        {
-          $array['password'] = UserHelper::hashPassword($array['password']);
-        }
-        else
-        {
-          unset($array['password']);
-        }
-      }
-    }
-
 		if(isset($array['params']) && \is_array($array['params']))
 		{
 			$registry = new Registry;
@@ -297,6 +293,22 @@ class CategoryTable extends Table implements VersionableTableInterface
 	public function store($updateNulls = true)
 	{
     $this->setPathWithLocation();
+
+    // Support for password field
+    if(isset($this->password))
+    {
+      if(\strlen($this->new_pw) > 0)
+      {
+        // Set a new password
+        $this->password = UserHelper::hashPassword($this->new_pw);
+      }
+
+      if($this->rm_pw)
+      {
+        // Remove current password
+        $this->password = '';
+      }
+    }
 
     // Support for params field
     if(isset($this->params) && !\is_string($this->params))

--- a/administrator/com_joomgallery/tmpl/category/edit.php
+++ b/administrator/com_joomgallery/tmpl/category/edit.php
@@ -31,6 +31,7 @@ $layout  = $isModal ? 'modal' : 'edit';
 $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
 ?>
 
+<div class="jg jg-category">
 <form
 	action="<?php echo Route::_('index.php?option=com_joomgallery&layout='.$layout.$tmpl.'&id=' . (int) $this->item->id); ?>"
 	method="post" enctype="multipart/form-data" name="adminForm" id="category-form" class="form-validate"
@@ -151,3 +152,4 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
 	<?php echo HTMLHelper::_('form.token'); ?>
 
 </form>
+</div>

--- a/administrator/com_joomgallery/tmpl/category/edit.php
+++ b/administrator/com_joomgallery/tmpl/category/edit.php
@@ -63,6 +63,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
 				<?php echo $this->form->renderField('published'); ?>
 				<?php echo $this->form->renderField('access'); ?>
 				<?php echo $this->form->renderField('password'); ?>
+        <?php echo $this->form->renderField('rm_password'); ?>
 				<?php echo $this->form->renderField('language'); ?>
 			</fieldset>
 		</div>

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -203,6 +203,9 @@ joomla-field-image .jg_minithumb {
 .jg .modal .btn {
   color: var(--white);
 }
+.jg-category .password-group > div.text-center {
+  display: none;
+}
 .uppy-Dashboard-inner {
   background-color: var(--white);
   border: none;


### PR DESCRIPTION
This PR adds the functionality of the password field in the backend category edit form.

When entering a passord and save the form the new password gets encrypted and saved to database.
If no password is entered in the form field, the old password is retained.

A field called "Remove password" is shown in the edit form when a password is currently set for this category. With this field the password can be removed.

### How to test this PR
- Test if the password is correctly stored to the database. You should see an encrypted hash in the categories db table.
- Test if the remove password is correctly shown and disabled if not needed.
- Test if the password is retained if you leave the form field empty.
- Test if you can remove the password.