### PR TITLE
Simplifying usage of addLog()

### DIFF
--- a/administrator/com_joomgallery/src/Extension/MessageTrait.php
+++ b/administrator/com_joomgallery/src/Extension/MessageTrait.php
@@ -177,15 +177,22 @@ trait MessageTrait
    * Log a message
    * 
    * @param   string   $txt       The message for a new log entry.
-   * @param   integer  $priority  Message priority.
+   * @param   mixed    $priority  Message priority.
    *
    * @return  void
    *
    * @since   4.0.0
   */
-  public function addLog(string $txt, int $priority = 8, string $name = null)
+  public function addLog(string $txt, $priority = 8, string $name = null)
   {
     $this->addLogger($name);
+
+    if(\is_string($priority))
+    {
+      $priority = \strtoupper($priority);
+      $constant = "Joomla\CMS\Log\Log::$priority";
+      $priority = \constant($constant);
+    }
     
     if(\is_null($name) && \is_null($this->logName))
     {
@@ -206,13 +213,13 @@ trait MessageTrait
    * Log a message
    * 
    * @param   string   $txt       The message for a new log entry.
-   * @param   integer  $priority  Message priority.
+   * @param   mixed    $priority  Message priority.
    *
    * @return  void
    *
    * @since   4.0.0
   */
-  public function setLog(string $txt, int $priority = 8, string $name = null)
+  public function setLog(string $txt, $priority = 8, string $name = null)
   {
     return $this->addLog($txt, $priority, $name);
   }

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -288,13 +288,13 @@ class CategoryModel extends JoomAdminModel
 
 					if($error)
 					{
-            $this->component->addLog($error, Log::WARNING, 'jerror');
+            $this->component->addLog($error, 'warning', 'jerror');
 
 						return false;
 					}
 					else
 					{
-            $this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
+            $this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning', 'jerror');
 
 						return false;
 					}

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -781,13 +781,13 @@ class ImageModel extends JoomAdminModel
 
 					if($error)
 					{
-						$this->component->addLog($error, Log::WARNING, 'jerror');
+						$this->component->addLog($error, 'warning', 'jerror');
 
 						return false;
 					}
 					else
 					{
-						$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
+						$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning', 'jerror');
 
 						return false;
 					}
@@ -852,7 +852,7 @@ class ImageModel extends JoomAdminModel
 					// Prune items that you can't change.
 					unset($pks[$i]);
 
-					$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), Log::WARNING, 'jerror');
+					$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), 'warning', 'jerror');
 
 					return false;
 				}
@@ -860,7 +860,7 @@ class ImageModel extends JoomAdminModel
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
 				if($table->hasField('checked_out') && $table->checked_out && ($table->checked_out != $user->id))
 				{
-					$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), Log::WARNING, 'jerror');
+					$this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'warning', 'jerror');
 
 					// Prune items that you can't change.
 					unset($pks[$i]);
@@ -1099,13 +1099,13 @@ class ImageModel extends JoomAdminModel
 
         if($error)
         {
-          $this->component->addLog($error, Log::WARNING, 'jerror');
+          $this->component->addLog($error, 'warning', 'jerror');
 
           return false;
         }
         else
         {
-          $this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
+          $this->component->addLog(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning', 'jerror');
 
           return false;
         }

--- a/administrator/com_joomgallery/src/Service/Messenger/MailMessenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/MailMessenger.php
@@ -63,7 +63,7 @@ class MailMessenger extends Messenger implements MessengerInterface
     {
       try
       {
-        $this->component->addLog(Text::_($exception->getMessage()), Log::WARNING, 'jerror');
+        $this->component->addLog(Text::_($exception->getMessage()), 'warning', 'jerror');
 
         $this->component->setError(Text::_('COM_JOOMGALLERY_ERROR_MAIL_FAILED'));
 


### PR DESCRIPTION
Before this PR `$this->component->addLog(string $txt, $priority = 8, string $name = null)` the second argument needed to be a integer with a proper value for the type of message based on the constants defined in `Joomla\CMS\Log\Log`.
With this PR it is now possible to choose the type of message by providing a string with the proper name of the message type.

**Before this PR**
`$this->component->addLog('My error message', 8, 'jerror')`
which is the same as
`$this->component->addLog('My error message', Log::ERROR, 'jerror')`

**After this PR**
`$this->component->addLog('My error message', 'error', 'jerror')`

Where the old way is still possible.

This fixes the issue reported in PR #239 

>0 Class “Joomgallery\Component\Joomgallery\Administrator\Model\Log” not found
1 () JROOT\administrator\components\com_joomgallery\src\Model\CategoryModel.php:297
2 Joomgallery\Component\Joomgallery\Administrator\Model\CategoryModel->delete() JROOT\libraries\src\MVC\Controller\AdminController.php:143
3 Joomla\CMS\MVC\Controller\AdminController->delete() JROOT\libraries\src\MVC\Controller\BaseController.php:693 

### How to test this PR
1. Open the file /com_joomgallery/administrator/src/View/Faulties and add the following code after line 49 (in front of the return statement):
`$this->component->addLog('My error message for testing.', 'warning', 'jerror');`

2. Visit the site with the following URL in your browser:
`http://<Your-Domain>/administrator/index.php?option=com_joomgallery&view=faulties`

3. Check that the message was added to the jerror log file
`/administrator/logs/com_joomgallery.jerror.log.php`

Repeat the test by changing the second argument in addLog() in step 1. Possible values for the second argument are:
all, emergency, alert, critical, error, warning, notice, info, debug