### PR TITLE
Migration: Time measurements

### DIFF
--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -1248,7 +1248,7 @@ class MigrationModel extends JoomAdminModel
     // Check the data.
     $start = microtime(true);
     $checkTable = $table->check();
-    $this->component->addLog('prepareTable();'.\strval(microtime(true) - $start), 128, 'migration');
+    $this->component->addLog('checkTable();'.\strval(microtime(true) - $start), 128, 'migration');
 
     if(!$checkTable)
     {

--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -142,7 +142,12 @@ class MigrationModel extends JoomAdminModel
         // Override params from user state with the one from db
         $params = \json_decode($params_db, true);
       }
-    }    
+    }
+
+    if(!\is_array($params))
+    {
+      $params = $params->toArray();
+    }
     
     return $params;
   }

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -318,7 +318,7 @@ class ImageTable extends Table implements VersionableTableInterface
       // Create tags
       $start = microtime(true);
       $this->tags = $tags_model->storeTagsList($this->tags);
-      $this->component->addLog('storeTagsList();'.\strval(microtime(true) - $start), 128, 'migration');
+      $com_obj ->addLog('storeTagsList();'.\strval(microtime(true) - $start), 128, 'migration');
       if($this->tags === false)
       {
         $this->setError('Tags Model reports '.$tags_model->getError());
@@ -328,7 +328,7 @@ class ImageTable extends Table implements VersionableTableInterface
       // Update tags mapping
       $start = microtime(true);
       $upd_mapping = $tags_model->updateMapping($this->tags, $this->id);
-      $this->component->addLog('updateMapping();'.\strval(microtime(true) - $start), 128, 'migration');
+      $com_obj->addLog('updateMapping();'.\strval(microtime(true) - $start), 128, 'migration');
 
       if(!$upd_mapping)
       {

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -316,7 +316,9 @@ class ImageTable extends Table implements VersionableTableInterface
     	$tags_model = $com_obj->getMVCFactory()->createModel('Tags', 'administrator');
 
       // Create tags
+      $start = microtime(true);
       $this->tags = $tags_model->storeTagsList($this->tags);
+      $this->component->addLog('storeTagsList();'.\strval(microtime(true) - $start), 128, 'migration');
       if($this->tags === false)
       {
         $this->setError('Tags Model reports '.$tags_model->getError());
@@ -324,7 +326,11 @@ class ImageTable extends Table implements VersionableTableInterface
       }
 
       // Update tags mapping
-      if(!$tags_model->updateMapping($this->tags, $this->id))
+      $start = microtime(true);
+      $upd_mapping = $tags_model->updateMapping($this->tags, $this->id);
+      $this->component->addLog('updateMapping();'.\strval(microtime(true) - $start), 128, 'migration');
+
+      if(!$upd_mapping)
       {
         $this->setError('Tags Model reports '.$tags_model->getError());
         $success = false;

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -347,6 +347,8 @@ class ImageTable extends Table implements VersionableTableInterface
 	 */
 	public function check()
 	{
+    $com_obj = Factory::getApplication()->bootComponent('com_joomgallery');
+
 		// If there is an ordering column and this is a new row then get the next ordering value
 		if(property_exists($this, 'ordering') && $this->id == 0)
 		{
@@ -354,6 +356,7 @@ class ImageTable extends Table implements VersionableTableInterface
 		}
 
 		// Check if alias is unique
+    $start = microtime(true);
 		if(!$this->isUnique('alias'))
 		{
 			$count = 2;
@@ -364,8 +367,10 @@ class ImageTable extends Table implements VersionableTableInterface
 				$this->alias = $currentAlias . '-' . $count++;
 			}
 		}
+    $com_obj->addLog('checkAlias();'.\strval(microtime(true) - $start), 128, 'migration');
 
     // Check if title is unique inside this category
+    $start = microtime(true);
 		if(!$this->isUnique('title', $this->catid, 'catid'))
 		{
 			$count = 2;
@@ -376,8 +381,10 @@ class ImageTable extends Table implements VersionableTableInterface
 				$this->title = $currentTitle . ' (' . $count++ . ')';
 			}
 		}
+    $com_obj->addLog('checkTitle();'.\strval(microtime(true) - $start), 128, 'migration');
 
 		// Support for subform field params
+    $start = microtime(true);
     if(empty($this->params))
     {
       $this->params = $this->loadDefaultField('params');
@@ -386,6 +393,7 @@ class ImageTable extends Table implements VersionableTableInterface
     {
       $this->params = new Registry($this->params);
     }
+    $com_obj->addLog('checkParamsField();'.\strval(microtime(true) - $start), 128, 'migration');
 
 		// Support for field description
     if(empty($this->description))
@@ -411,7 +419,11 @@ class ImageTable extends Table implements VersionableTableInterface
       $this->imgmetadata = $this->loadDefaultField('imgmetadata');
     }
 
-		return parent::check();
+    $start = microtime(true);
+    $succ = parent::check();
+    $com_obj->addLog('checkTableParent();'.\strval(microtime(true) - $start), 128, 'migration');
+
+		return $succ;
 	}
 
   /**


### PR DESCRIPTION
This PR adds a time measurement for all the steps taken during the migration of a migrateable (category, image). The times are taken and outputted into the log file `com_joomgallery.migration.log.php`.

If you want to take measurements of your current migration, then
1. Copy the file `administrator/com_joomgallery/src/Model/MigrationModel.php` of this PR
2. Replace the file in your current JoomGallery installation
3. Perfrom a migration
4. Look into the log file