### PR TITLE
Add missing field jg_userupload

### DIFF
--- a/administrator/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/com_joomgallery/sql/install.mysql.utf8.sql
@@ -182,6 +182,7 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_configs` (
 `jg_maxuserimage` DOUBLE NOT NULL DEFAULT 500,
 `jg_maxuserimage_timespan` DOUBLE NOT NULL DEFAULT 0,
 `jg_maxfilesize` DOUBLE NOT NULL DEFAULT 2000000,
+`jg_userupload` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_newpiccopyright` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_uploaddefaultcat` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_useruploadsingle` TINYINT(1) NOT NULL DEFAULT 1,

--- a/administrator/com_joomgallery/sql/updates/mysql/4.0.0.sql
+++ b/administrator/com_joomgallery/sql/updates/mysql/4.0.0.sql
@@ -182,6 +182,7 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_configs` (
 `jg_maxuserimage` DOUBLE NOT NULL DEFAULT 500,
 `jg_maxuserimage_timespan` DOUBLE NOT NULL DEFAULT 0,
 `jg_maxfilesize` DOUBLE NOT NULL DEFAULT 2000000,
+`jg_userupload` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_newpiccopyright` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_uploaddefaultcat` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_useruploadsingle` TINYINT(1) NOT NULL DEFAULT 1,


### PR DESCRIPTION
The following setting in the JoomGallery configuration is currently not saved:
`User Settings -> Uploads -> Frontend upload`

### How to test this PR

Make a new installation, not an update.
Change the field 'Fronted upload' and save your setting.
Check if the correct setting is available after closing and reopening.