### PR TITLE
Change of the 'Image types' names

### DIFF
--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -402,6 +402,28 @@ class JoomHelper
     // Create file config service based on current user
 		$config = self::getService('Config');
 
+    // Adjust type when in compatibility mode
+    if($config->get('jg_compatibility_mode', 0))
+    {
+      switch($type)
+      {
+        case 'thumb':
+          $type = 'thumbnail';
+          break;
+        
+        case 'img':
+          $type = 'detail';
+          break;
+
+        case 'orig':
+          $type = 'original';
+          break;
+        
+        default:
+          break;
+      }
+    }
+
     if(\strpos($type, 'rnd_cat:') !== false && $config->get('jg_category_view_subcategories_random_image', 1))
     {
       // we want to get a random image from a category


### PR DESCRIPTION
This PR fixes the issue reported in #213 
When compatibility mode activated, the old image type names gets forewarded to the new ones. This way the old image source paths should work again.

**Old (JG3)**
index.php?option=com_joomgallery&view=image&format=raw&id=123&type=img

**New (JG4)**
index.php?option=com_joomgallery&view=image&format=raw&id=123&type=detail