### PR TITLE
Category alias rename fix

### DIFF
--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -390,7 +390,7 @@ class CategoryTable extends Table implements VersionableTableInterface
     // Create new path based on alias and parent category
     $manager    = JoomHelper::getService('FileManager', array($this->id));
     $filesystem = JoomHelper::getService('Filesystem');
-    $this->path = $manager->getCatPath($this->id, false, $this->parent_id, $this->alias, false, false);
+    $this->path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, false);
     $this->path = $filesystem->cleanPath($this->path, '/');
 
     // Support for subform field params


### PR DESCRIPTION
This PR fixes the issue reported in #236.
The category path in the DB gets now correctly adapted when the alias changes.