### PR TITLE
Fix issues in ListAdminModel

### DIFF
--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -656,18 +656,19 @@ abstract class JoomAdminModel extends AdminModel
    */
   protected function canDelete($record)
   {
-    $id        = $record->id;
-    $parent_id = 0;
-    $use_parent = false;
+    $id                  = $record->id;
+    $parent_id           = 0;
+    $use_parent          = false;
+    list($option, $type) = \explode('.', $this->type->type_alias, 2);
 
-    if(\in_array($this->type, $this->getAcl()->get('parent_dependent_types')) && isset($record->catid))
+    if(\in_array($type, $this->getAcl()->get('parent_dependent_types')) && isset($record->catid))
     {
       // We have a parent dependent content type, so parent_id is needed
       $parent_id = $record->catid;
       $use_parent = true;
     }
 
-    return $this->getAcl()->checkACL('delete', $this->type, $id, $parent_id, $use_parent);
+    return $this->getAcl()->checkACL('delete', $type, $id, $parent_id, $use_parent);
   }
 
   /**
@@ -681,18 +682,19 @@ abstract class JoomAdminModel extends AdminModel
    */
   protected function canEditState($record)
   {
-    $id         = $record->id;
-    $parent_id  = 0;
-    $use_parent = false;
+    $id                  = $record->id;
+    $parent_id           = 0;
+    $use_parent          = false;
+    list($option, $type) = \explode('.', $this->type->type_alias, 2);
 
-    if(\in_array($this->type, $this->getAcl()->get('parent_dependent_types')) && $record->id > 0)
+    if(\in_array($type, $this->getAcl()->get('parent_dependent_types')) && $record->id > 0)
     {
       // We have a parent dependent content type, so parent_id is needed
-      $parent_id  = isset($record->catid) ? $record->catid : JoomHelper::getParent($this->type, $record->id);
+      $parent_id  = isset($record->catid) ? $record->catid : JoomHelper::getParent($type, $record->id);
       $use_parent = true;
     }
 
-    return $this->getAcl()->checkACL('editstate', $this->type, $id, $parent_id, $use_parent);
+    return $this->getAcl()->checkACL('editstate', $type, $id, $parent_id, $use_parent);
   }
 
   /**

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -330,7 +330,7 @@ abstract class JoomAdminModel extends AdminModel
    */
   public function initBatch()
   {
-    parent::iniBatch();
+    parent::initBatch();
 
     // Get current user
     $this->user = $this->component->getMVCFactory()->getIdentity();

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -656,10 +656,15 @@ abstract class JoomAdminModel extends AdminModel
    */
   protected function canDelete($record)
   {
-    $id                  = $record->id;
-    $parent_id           = 0;
-    $use_parent          = false;
-    list($option, $type) = \explode('.', $this->type->type_alias, 2);
+    $id         = $record->id;
+    $parent_id  = 0;
+    $use_parent = false;
+    $type       = $this->type;
+
+    if(\is_object($this->type))
+    {
+      list($option, $type) = \explode('.', $this->type->type_alias, 2);
+    }
 
     if(\in_array($type, $this->getAcl()->get('parent_dependent_types')) && isset($record->catid))
     {
@@ -682,10 +687,15 @@ abstract class JoomAdminModel extends AdminModel
    */
   protected function canEditState($record)
   {
-    $id                  = $record->id;
-    $parent_id           = 0;
-    $use_parent          = false;
-    list($option, $type) = \explode('.', $this->type->type_alias, 2);
+    $id         = $record->id;
+    $parent_id  = 0;
+    $use_parent = false;
+    $type       = $this->type;
+
+    if(\is_object($this->type))
+    {
+      list($option, $type) = \explode('.', $this->type->type_alias, 2);
+    }      
 
     if(\in_array($type, $this->getAcl()->get('parent_dependent_types')) && $record->id > 0)
     {


### PR DESCRIPTION
This PR fixes issue #268.
There were two errors on top of each other preventing the ordering of records in list views of JoomGallery. This PR fixes this issue for all list views.

**Errors which are fixed:**
- Typo when initializing a batch process in JoomAdminModel
  --> Dragndrop sorting uses the batch process of the list model. Thats why sorting failed.
- Error introduced with PR #261 when checking permissions within the JoomAdminModel
  --> Therefore ACL checks on canDelete, canEditState failed