### PR TITLE
Breadcrumbs

### DIFF
--- a/administrator/com_joomgallery/forms/config.xml
+++ b/administrator/com_joomgallery/forms/config.xml
@@ -437,7 +437,7 @@
         <field name="jg_userspace"
               type="radio"
               default="1"
-              class="btn-group unused"
+              class="btn-group"
               layout="joomla.form.field.radio.switcher"
               label="COM_JOOMGALLERY_CONFIG_USERSPACE"
               description="COM_JOOMGALLERY_CONFIG_USERSPACE_LONG" >

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -657,17 +657,26 @@ class JoomHelper
    *
    * @since   4.0.0
    */
-  public static function getViewRoute($view, $id, $catid = null, $language = null, $layout = null)
+  public static function getViewRoute($view, $id, $catid = 0, $language = 0, $layout = null)
   {
+    if(\is_object($id))
+    {
+      $id = (int) $id->id;
+    }
+    else
+    {
+      $id = (int) $id;
+    }
+
     // Create the link
     $link = 'index.php?option=com_joomgallery&view='.$view.'&id=' . $id;
 
-    if((int) $catid > 1)
+    if((int) $catid > 0)
     {
       $link .= '&catid=' . $catid;
     }
 
-    if(!empty($language) && $language !== '*' && Multilanguage::isEnabled())
+    if($language && $language !== '*' && Multilanguage::isEnabled())
     {
       $link .= '&lang=' . $language;
     }
@@ -691,12 +700,12 @@ class JoomHelper
    *
    * @since   4.0.0
    */
-  public static function getListRoute($view, $language = null, $layout = null)
+  public static function getListRoute($view, $language = 0, $layout = null)
   {
     // Create the link
     $link = 'index.php?option=com_joomgallery&view='.$view;
 
-    if(!empty($language) && $language !== '*' && Multilanguage::isEnabled())
+    if($language && $language !== '*' && Multilanguage::isEnabled())
     {
       $link .= '&lang=' . $language;
     }

--- a/site/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categories/HtmlView.php
@@ -62,6 +62,15 @@ class HtmlView extends JoomGalleryView
 			throw new GenericDataException(\implode("\n", $errors), 500);
 		}
 
+    // Check if is userspace is enabled
+    // Check access permission (ACL)
+    if($this->params['configs']->get('jg_userspace', 1, 'int') == 0 || !$this->getAcl()->checkACL('manage', 'com_joomgallery'))
+    {
+      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
+      
+      return false;
+    }
+
 		// Preprocess the list of items to find ordering divisions.
 		foreach($this->items as &$item)
 		{
@@ -136,7 +145,7 @@ class HtmlView extends JoomGalleryView
 
     if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbTitle);
+      $pathway->addItem($breadcrumbTitle, '');
     }
 	}
 }

--- a/site/com_joomgallery/src/View/Category/HtmlView.php
+++ b/site/com_joomgallery/src/View/Category/HtmlView.php
@@ -154,20 +154,39 @@ class HtmlView extends JoomGalleryView
 			$this->document->setMetadata('robots', $this->params['menu']->get('robots'));
 		}
 
-    // Add Breadcrumbs
-    $pathway = $this->app->getPathway();
-    $breadcrumbList = Text::_('COM_JOOMGALLERY_CATEGORIES');
-
-    if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
+    // Get ID of the category from active menu item
+    if($this->menu && $this->menu->component == _JOOM_OPTION && isset($this->menu->query['view']) && in_array($this->menu->query['view'], ['categories', 'category']))
     {
-      $pathway->addItem($breadcrumbList, "index.php?option=com_joomgallery&view=categories");
+      $id = $this->menu->query['id'];
+    }
+    else
+    {
+      $id = 1;
     }
 
-    $breadcrumbTitle = Text::_('JCATEGORY');
-
-    if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
+    // Add Breadcrumbs
+    if($this->item->id > 1)
     {
-      $pathway->addItem($breadcrumbTitle);
+      $path = [['title' => $this->item->title, 'link' => '']];
+    }
+    else
+    {
+      $path = [];
+    }
+    
+    $category = $this->item->parent;
+    
+    while($category !== null && $category->id !== 1 && $category->id != $id)
+    {
+      $path[]   = ['title' => $category->title, 'link' => JoomHelper::getViewRoute('category', $category->id, 0, $category->language)];
+      $category = $this->getModel()->getParent($category->parent_id);
+    }
+
+    $path = \array_reverse($path);
+
+    foreach($path as $item)
+    {
+      $this->app->getPathway()->addItem($item['title'], $item['link']);
     }
 	}
 }

--- a/site/com_joomgallery/src/View/Categoryform/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categoryform/HtmlView.php
@@ -84,17 +84,17 @@ class HtmlView extends JoomGalleryView
     // Get return page
     $this->return_page = $this->get('ReturnPage');
 
-    // Check acces view level
-		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
-    {
-      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
-    }
-
 		// Check for errors.
 		if(\count($errors = $this->get('Errors')))
 		{
 			throw new GenericDataException(\implode("\n", $errors), 500);
 		}
+
+    // Check acces view level
+		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+    {
+      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
+    }
 
 		$this->_prepareDocument();
 
@@ -164,14 +164,14 @@ class HtmlView extends JoomGalleryView
 
     if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbList, "index.php?option=com_joomgallery&view=categories");
+      $pathway->addItem($breadcrumbList, 'index.php?option=com_joomgallery&view=categories');
     }
 
     $breadcrumbTitle = isset($this->item->id) ? Text::_("JGLOBAL_EDIT") : Text::_("JGLOBAL_FIELD_ADD");
 
     if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbTitle);
+      $pathway->addItem($breadcrumbTitle, '');
     }
 	}
 }

--- a/site/com_joomgallery/src/View/Gallery/HtmlView.php
+++ b/site/com_joomgallery/src/View/Gallery/HtmlView.php
@@ -124,21 +124,5 @@ class HtmlView extends JoomGalleryView
 		{
 			$this->document->setMetadata('robots', $this->params['menu']->get('robots'));
 		}
-
-    // Add Breadcrumbs
-    // $pathway = $this->app->getPathway();
-    // $breadcrumbList = Text::_('COM_JOOMGALLERY_IMAGES');
-
-    // if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
-    // {
-    //   $pathway->addItem($breadcrumbList, "index.php?option=com_joomgallery&view=images");
-    // }
-
-    // $breadcrumbTitle = Text::_('COM_JOOMGALLERY_IMAGES');
-
-    // if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
-    // {
-    //   $pathway->addItem($breadcrumbTitle);
-    // }
 	}
 }

--- a/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -138,14 +138,14 @@ class HtmlView extends JoomGalleryView
 
     if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbList, "index.php?option=com_joomgallery&view=images");
+      $pathway->addItem($breadcrumbList, 'index.php?option=com_joomgallery&view=gallery');
     }
 
-    $breadcrumbTitle = Text::_('COM_JOOMGALLERY_IMAGES');
+    $breadcrumbTitle = $this->item->title;
 
     if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbTitle);
+      $pathway->addItem($breadcrumbTitle, '');
     }
 	}
 }

--- a/site/com_joomgallery/src/View/Imageform/HtmlView.php
+++ b/site/com_joomgallery/src/View/Imageform/HtmlView.php
@@ -164,14 +164,14 @@ class HtmlView extends JoomGalleryView
 
     if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbList, "index.php?option=com_joomgallery&view=images");
+      $pathway->addItem($breadcrumbList, 'index.php?option=com_joomgallery&view=images');
     }
 
-    $breadcrumbTitle = isset($this->item->id) ? Text::_("JGLOBAL_EDIT") : Text::_("JGLOBAL_FIELD_ADD");
+    $breadcrumbTitle = isset($this->item->id) ? Text::_('JGLOBAL_EDIT') : Text::_('JGLOBAL_FIELD_ADD');
 
     if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbTitle);
+      $pathway->addItem($breadcrumbTitle, '');
     }
 	}
 }

--- a/site/com_joomgallery/src/View/Images/HtmlView.php
+++ b/site/com_joomgallery/src/View/Images/HtmlView.php
@@ -63,7 +63,14 @@ class HtmlView extends JoomGalleryView
 			throw new GenericDataException(\implode("\n", $errors), 500);
 		}
 
-    // Check acces view level
+    // Check if is userspace is enabled
+    // Check access permission (ACL)
+    if($this->params['configs']->get('jg_userspace', 1, 'int') == 0 || !$this->getAcl()->checkACL('manage', 'com_joomgallery'))
+    {
+      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
+      
+      return false;
+    }
 
 		$this->_prepareDocument();
 
@@ -133,7 +140,7 @@ class HtmlView extends JoomGalleryView
 
     if(!\in_array($breadcrumbTitle, $pathway->getPathwayNames()))
     {
-      $pathway->addItem($breadcrumbTitle);
+      $pathway->addItem($breadcrumbTitle, '');
     }
 	}
 }

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -31,7 +31,9 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
   <p>This is the default JoomGallery-Page. In the future, this will become a beautiful image wall page with search bar and filters. A perfect entry point to your gallery.</p>
   <ul>
     <li><a href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id=1'); ?>">Category View</a></li>
-    <li><a href="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>">Categories List View</a></li>
-    <li><a href="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>">Images List View</a></li>
+    <?php if($this->params['configs']->get('jg_userspace', 1, 'int') == 1): ?>
+      <li><a href="<?php echo Route::_('index.php?option=com_joomgallery&view=categories'); ?>">Categories List View</a></li>
+      <li><a href="<?php echo Route::_('index.php?option=com_joomgallery&view=images'); ?>">Images List View</a></li>
+    <?php endif; ?>
   </ul>
 </div>


### PR DESCRIPTION
This PR adds the pathways to the Joomla application when visiting frontend views such that the breadcrumbs can be created with the module `mod_breadcrumbs`.

![grafik](https://github.com/user-attachments/assets/964bb374-c40e-4025-af27-d4f46340640b)

### Testing instructions
Visit the frontend views and check if the breadcrumbs are created in such a way you would expect when using the core articles `com_content`.