### PR TITLE
Remove listlimit dropdown from Category View

### DIFF
--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -209,7 +209,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
         {
           echo LayoutHelper::render('joomla.searchtools.default', array(
             'view' => $this->item->images, 
-            'options' => array('showSelector' => false, 'filterButton' => false, 'showNoResults' => false, 'showSearch' => false, 'barClass' => 'flex-end')
+            'options' => array('showSelector' => false, 'filterButton' => false, 'showNoResults' => false, 'showSearch' => false, 'showList' => false, 'barClass' => 'flex-end')
           ));
         }
       ?>


### PR DESCRIPTION
There is currently a dropdown in the category view used to change the number of images displayed. However, this causes various problems. Problem description: https://github.com/JoomGalleryfriends/JG4-dev/pull/269#issuecomment-2428759200
This PR removes the dropdown in the category view.
Unfortunately, this also removes the sorting of the images as currently only both can be deactivated together.
![category-view-listlimit](https://github.com/user-attachments/assets/a38d3115-d9c4-4f0f-ad2b-9482e380c902)

DE:
Aktuell gibt es in der Category View ein Dropdown mit dem die Anzahl der angezeigten Bildern verändert werden kann. Dadurch entstehen aber verschiedene Probleme. Problembeschreibung: https://github.com/JoomGalleryfriends/JG4-dev/pull/269#issuecomment-2428759200
Dieser PR entfernt das Dropdown in der Category View.
Leider wird dadurch auch die Sortierung der Bilder mit entfernt da aktuell nur beides zusammen deaktivierbar ist.