### PR TITLE
Delete old menuitems when uninstallation

### DIFF
--- a/script.php
+++ b/script.php
@@ -404,6 +404,49 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $db->setQuery($query);
     $db->execute();
 
+    // Delete frontend menuitems
+    // Delete Gallery menuitem
+    $query
+      ->clear()
+      ->delete('#__menu')
+      ->where(
+        array(
+          'menutype = ' . $db->quote('mainmenu'),
+          'link = ' . $db->quote('index.php?option=com_joomgallery&view=gallery')
+        )
+      );
+
+    $db->setQuery($query);
+    $db->execute();
+
+    // Delete Categories menuitem
+    $query
+      ->clear()
+      ->delete('#__menu')
+      ->where(
+        array(
+          'menutype = ' . $db->quote('mainmenu'),
+          'link = ' . $db->quote('index.php?option=com_joomgallery&view=category&id=1')
+        )
+      );
+
+    $db->setQuery($query);
+    $db->execute();
+
+    // Delete Images menuitem
+    $query
+      ->clear()
+      ->delete('#__menu')
+      ->where(
+        array(
+          'menutype = ' . $db->quote('mainmenu'),
+          'link = ' . $db->quote('index.php?option=com_joomgallery&view=images')
+        )
+      );
+
+    $db->setQuery($query);
+    $db->execute();
+
     // Delete directories
     if(!Folder::delete(JPATH_ROOT.'/images/joomgallery'))
     {


### PR DESCRIPTION
Fix for Issue https://github.com/JoomGalleryfriends/JG4-dev/issues/278

During the installation of JoomGallery, three menu entries are automatically created.
When JoomGallery is uninstalled, the orphaned menu entries are left behind.
With this PR the menu entries are deleted when JoomGallery is uninstalled.

DE:
Während der Installation der JoomGallery werden automatisch drei Menüeinträge angelegt.
Bei der Deinstallation der JoomGallery bleiben die verwaisten Menüeinträge zurück.
Mit diesem PR werden die Menüeinträge gelöscht wenn die JoomGallery deinstalliert wird.