### PR TITLE
Fixes different upload issues

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -700,6 +700,7 @@ COM_JOOMGALLERY_SERVICE_ERROR_COPY_METADATA="ERROR: Metadata could not be copied
 COM_JOOMGALLERY_SERVICE_GD_NOT_INSTALLED="GD image library not installed!"
 COM_JOOMGALLERY_SERVICE_GD_NO_TRUECOLOR="GD image library does not support truecolor resizing!"
 COM_JOOMGALLERY_SERVICE_GD_SUPPORTED_TYPES="ERROR: GD is processing only %s files!"
+COM_JOOMGALLERY_SERVICE_GD_NOT_KEEP_TRANSPARENCY="GD in its current version can not keep transparency of images with type %s."
 COM_JOOMGALLERY_SERVICE_RESIZE_NOT_NEEDED="Resize is not necessary because the image is already small enough."
 COM_JOOMGALLERY_SERVICE_ROTATE_NOT_NEEDED="Rotation is not necessary."
 COM_JOOMGALLERY_SERVICE_FLIP_NOT_NEEDED="Flipping the image is not necessary."

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -750,6 +750,7 @@ COM_JOOMGALLERY_SERVICE_DEBUG_REPLACE_AUTHOR="Image author was replaced by metad
 COM_JOOMGALLERY_SERVICE_DEBUG_REPLACE_DATE="Image date was replaced by metadata."
 COM_JOOMGALLERY_SERVICE_DEBUG_REPLACE_METAKEYS="Meta keywords was replaced by metadata."
 COM_JOOMGALLERY_SERVICE_DEBUG_REPLACE_METADESC="Meta description was replaced by metadata."
+COM_JOOMGALLERY_SERVICE_DEBUG_REPLACE_ALIAS_FILENAME="As the image title has been replaced, the alias and the filename were adjusted accordingly."
 COM_JOOMGALLERY_SERVICE_ERROR_MEMORY_EXCEED="Memory limit exceeded. No further processing of the image. Memory requirement: %s. Ask your webhoster for more information."
 COM_JOOMGALLERY_SERVICE_ERROR_EXEC_DISABLED="The function exec() has been disabled in php.ini. It's not possible to use ImageMagick in JoomGallery because of this disabled function. Ask your webhoster for more information."
 COM_JOOMGALLERY_SERVICE_SERVERPROBLEM_EXEC="ERROR: Server problem. The following statement could not be executed in the php code: '%s'"

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -14,7 +14,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Factory;
-use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Utilities\ArrayHelper;

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -12,13 +12,10 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\FileManager;
 
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Language\Text;
-
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\FileManager\FileManagerInterface;
-
 use \Joomla\Component\Media\Administrator\Exception\FileExistsException;
 use \Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 use \Joomla\Component\Media\Administrator\Exception\InvalidPathException;
@@ -133,6 +130,18 @@ class FileManager implements FileManagerInterface
 
       // Debug info
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_PROCESSING_IMAGETYPE', $imagetype->typename), true, true);
+
+      // For original images: check if processing is really needed
+      if( $imagetype->typename == 'original' && $processing &&
+          $imagetype->params->get('jg_imgtypeanim', 0) == 1 &&
+          $imagetype->params->get('jg_imgtypeorinet', 0) == 0 &&
+          $imagetype->params->get('jg_imgtyperesize', 0) == 0 &&
+          $imagetype->params->get('jg_imgtypewatermark', 0) == 0
+        )
+      {
+        $processing = false;
+      }
+
 
       // Process image
       if($processing)

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -1181,8 +1181,9 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
         $this->dst_frames[$key]['image'] = $this->imageRotate_GD($this->src_frames[$key]['image'], $this->src_type,
                                                                  $this->dst_imginfo['angle'], $this->src_imginfo['transparency']);
 
-        $this->dst_imginfo['width']      = imagesx($this->dst_frames[$key]['image']);
-        $this->dst_imginfo['height']     = imagesy($this->dst_frames[$key]['image']);
+        $this->dst_imginfo['width']       = imagesx($this->dst_frames[$key]['image']);
+        $this->dst_imginfo['height']      = imagesy($this->dst_frames[$key]['image']);
+        $this->dst_imginfo['orientation'] = $this->getOrientation($this->dst_imginfo['width'], $this->dst_imginfo['height']);
       }
 
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ROTATE_BY_ANGLE', $this->dst_imginfo['angle']));

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -798,11 +798,15 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->manipulated = true;
 
     // Clean up working area (frames and imginfo)
-    $this->res_frames                 = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+    $this->res_frames = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+
+    $this->clearImginfo('res');
     $this->res_imginfo                = $this->src_imginfo;
     $this->res_imginfo['width']       = $this->dst_imginfo['width'];
     $this->res_imginfo['height']      = $this->dst_imginfo['height'];
     $this->res_imginfo['orientation'] = $this->dst_imginfo['orientation'];
+
+    $this->clearImginfo(array('src', 'dst'));
     $this->deleteFrames_GD(array('src_frames', 'dst_frames'));
 
     return true;
@@ -843,12 +847,13 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->src_imginfo = $this->res_imginfo;
 
     // Get info for destination frames
-    $this->dst_imginfo['angle']    = $angle;
-    $this->dst_imginfo['flip']     = 'none';
-    $this->dst_imginfo['width']    = $this->dst_imginfo['src']['width']  = $this->src_imginfo['width'];
-    $this->dst_imginfo['height']   = $this->dst_imginfo['src']['height'] = $this->src_imginfo['height'];
-    $this->dst_imginfo['offset_x'] = 0;
-    $this->dst_imginfo['offset_y'] = 0;
+    $this->dst_imginfo['angle']     = $angle;
+    $this->dst_imginfo['flip']      = 'none';
+    $this->dst_imginfo['width']     = $this->dst_imginfo['src']['width']  = $this->src_imginfo['width'];
+    $this->dst_imginfo['height']    = $this->dst_imginfo['src']['height'] = $this->src_imginfo['height'];
+    $this->dst_imginfo['offset_x']  = 0;
+    $this->dst_imginfo['offset_y']  = 0;
+    $this->dst_imginfo['truecolor'] = $this->src_imginfo['truecolor'];
 
     // Calculation for the amount of memory needed (in bytes, GD)
     $this->memory_needed = $this->calculateMemory($this->src_imginfo, $this->dst_imginfo, 'rotate');
@@ -923,11 +928,15 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->manipulated = true;
 
     // Clean up working area (frames and imginfo)
-    $this->res_frames                 = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+    $this->res_frames = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+
+    $this->clearImginfo('res');
     $this->res_imginfo                = $this->src_imginfo;
     $this->res_imginfo['width']       = $this->dst_imginfo['width'];
     $this->res_imginfo['height']      = $this->dst_imginfo['height'];
     $this->res_imginfo['orientation'] = $this->dst_imginfo['orientation'];
+
+    $this->clearImginfo(array('src', 'dst'));
     $this->deleteFrames_GD(array('src_frames', 'dst_frames'));
 
     return true;
@@ -989,6 +998,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->dst_imginfo['width']       = $this->dst_imginfo['src']['width']  = $this->src_imginfo['width'];
     $this->dst_imginfo['height']      = $this->dst_imginfo['src']['height'] = $this->src_imginfo['height'];
     $this->dst_imginfo['orientation'] = $this->src_imginfo['orientation'];
+    $this->dst_imginfo['truecolor']   = $this->src_imginfo['truecolor'];
     $this->dst_imginfo['offset_x']    = 0;
     $this->dst_imginfo['offset_y']    = 0;
     $this->dst_imginfo['angle']       = 0;
@@ -1066,11 +1076,15 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->manipulated = true;
 
     // Clean up working area (frames and imginfo)
-    $this->res_frames                 = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+    $this->res_frames= $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+
+    $this->clearImginfo(array('res'));
     $this->res_imginfo                = $this->src_imginfo;
     $this->res_imginfo['width']       = $this->dst_imginfo['width'];
     $this->res_imginfo['height']      = $this->dst_imginfo['height'];
     $this->res_imginfo['orientation'] = $this->dst_imginfo['orientation'];
+
+    $this->clearImginfo(array('src', 'dst'));
     $this->deleteFrames_GD(array('src_frames', 'dst_frames'));
 
     return true;
@@ -1114,10 +1128,11 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     {
       $this->autoOrient($this->metadata['exif']['IFD0']['Orientation']);
     }
-    $this->dst_imginfo['width']    = $this->dst_imginfo['src']['width']  = $this->src_imginfo['width'];
-    $this->dst_imginfo['height']   = $this->dst_imginfo['src']['height'] = $this->src_imginfo['height'];
-    $this->dst_imginfo['offset_x'] = 0;
-    $this->dst_imginfo['offset_y'] = 0;
+    $this->dst_imginfo['width']     = $this->dst_imginfo['src']['width']  = $this->src_imginfo['width'];
+    $this->dst_imginfo['height']    = $this->dst_imginfo['src']['height'] = $this->src_imginfo['height'];
+    $this->dst_imginfo['offset_x']  = 0;
+    $this->dst_imginfo['offset_y']  = 0;
+    $this->dst_imginfo['truecolor'] = $this->src_imginfo['truecolor'];
 
     // Create empty destination GD-Objects of specified size
     if($this->keep_anim && $this->src_imginfo['animation'] && $this->src_type == 'GIF')
@@ -1205,11 +1220,15 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->manipulated = true;
 
     // Clean up working area (frames and imginfo)
-    $this->res_frames                 = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+    $this->res_frames = $this->copyFrames_GD($this->dst_frames, $this->dst_imginfo, $this->src_imginfo['transparency']);
+
+    $this->clearImginfo(array('res'));
     $this->res_imginfo                = $this->src_imginfo;
     $this->res_imginfo['width']       = $this->dst_imginfo['width'];
     $this->res_imginfo['height']      = $this->dst_imginfo['height'];
     $this->res_imginfo['orientation'] = $this->dst_imginfo['orientation'];
+
+    $this->clearImginfo(array('src', 'dst'));
     $this->deleteFrames_GD(array('src_frames', 'dst_frames'));
 
     return true;
@@ -1387,9 +1406,13 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $this->manipulated = true;
 
     // Clean up working area (frames and imginfo)
-    $this->res_frames  = $this->copyFrames_GD($this->src_frames, $this->src_imginfo, $this->src_imginfo['transparency']);
+    $this->res_frames = $this->copyFrames_GD($this->src_frames, $this->src_imginfo, $this->src_imginfo['transparency']);
+
+    $this->clearImginfo(array('res'));
     $this->res_imginfo = $this->src_imginfo;
     $this->src_type    = $bkg_type;
+
+    $this->clearImginfo(array('src', 'dst'));
     $this->deleteFrames_GD(array('src_frames', 'dst_frames'));
 
     return true;
@@ -1893,54 +1916,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     if($transparency)
     {
       // Set transparent backgraound
-      switch ($this->src_type)
-      {
-        case 'GIF':
-          if(\function_exists('imagecolorallocatealpha'))
-          {
-            // Needs at least php v4.3.2
-            $trnprt_color = \imagecolorallocatealpha($src_frame, 0, 0, 0, 127);
-            \imagefill($src_frame, 0, 0, $trnprt_color);
-            \imagecolortransparent($src_frame, $trnprt_color);
-          }
-          else
-          {
-            $trnprt_indx = \imagecolortransparent($src_frame);
-            $palletsize  = \imagecolorstotal($src_frame);
-
-            if($trnprt_indx >= 0 && $trnprt_indx < $palletsize)
-            {
-              $trnprt_color = \imagecolorsforindex($src_frame, $trnprt_indx);
-              $trnprt_indx  = \imagecolorallocate($src_frame, $trnprt_color['red'], $trnprt_color['green'], $trnprt_color['blue']);
-              \imagefill($src_frame, 0, 0, $trnprt_indx);
-              \imagecolortransparent($src_frame, $trnprt_indx);
-            }
-          }
-        break;
-        case 'PNG':
-          if(\function_exists('imagecolorallocatealpha'))
-          {
-            // Needs at least php v4.3.2
-            \imagealphablending($src_frame, false);
-            $trnprt_color = \imagecolorallocatealpha($src_frame, 0, 0, 0, 127);
-            \imagefill($src_frame, 0, 0, $trnprt_color);
-          }
-        break;
-        case 'WEBP':
-          if(\function_exists('imagecolorallocatealpha'))
-          {
-            // Needs at least php v4.3.2
-            \imagealphablending($src_frame, false);
-            $trnprt_color = \imagecolorallocatealpha($src_frame, 0, 0, 0, 127);
-            \imagefill($src_frame, 0, 0, $trnprt_color);
-          }
-        break;
-        default:
-          $src_frame = false;
-
-          return $src_frame;
-        break;
-      }
+      $src_frame = $this->keepTransparency_GD($src_frame, $dst_imginfo['truecolor']);
     }
     else
     {
@@ -2189,6 +2165,61 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
   }
 
   /**
+   * ake sure background is still transparent
+   *
+   * @param   object     $img_frame     GDobject of the image to rotate
+   * @param   bool       $truecolor     True if the image is a truecolor image
+   *
+   * @return  mixed      GDobject on success, false otherwise
+   *
+   * @since   4.0.0
+   */
+  protected function keepTransparency_GD($img_frame, $truecolor = true)
+  {
+    if($truecolor)
+    {
+      if(\function_exists('imagecolorallocatealpha'))
+      {
+        // Needs at least php v4.3.2
+        \imagealphablending($img_frame, false);
+        \imagesavealpha($img_frame, true);
+        $trnprt_color = \imagecolorallocatealpha($img_frame, 0, 0, 0, 127);
+        \imagefill($img_frame, 0, 0, $trnprt_color);
+      }
+      else
+      {
+        // Transparency can not be kept using GD
+        $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_GD_NOT_KEEP_TRANSPARENCY', $this->src_type));
+      }
+    }
+    else
+    {
+      if(\function_exists('imagecolorallocatealpha'))
+      {
+        // Needs at least php v4.3.2
+        $trnprt_color = \imagecolorallocatealpha($img_frame, 0, 0, 0, 127);
+        \imagefill($img_frame, 0, 0, $trnprt_color);
+        \imagecolortransparent($img_frame, $trnprt_color);
+      }
+      else
+      {
+        $trnprt_indx = \imagecolortransparent($img_frame);
+        $palletsize  = \imagecolorstotal($img_frame);
+
+        if($trnprt_indx >= 0 && $trnprt_indx < $palletsize)
+        {
+          $trnprt_color = \imagecolorsforindex($img_frame, $trnprt_indx);
+          $trnprt_indx  = \imagecolorallocate($img_frame, $trnprt_color['red'], $trnprt_color['green'], $trnprt_color['blue']);
+          \imagefill($img_frame, 0, 0, $trnprt_indx);
+          \imagecolortransparent($img_frame, $trnprt_indx);
+        }
+      }
+    }
+
+    return $img_frame;
+  }
+
+  /**
    * Watermark GD image object (copy watermark on top of image)
    *
    * @param   object     $img_frame     GDobject of the image
@@ -2209,6 +2240,12 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     $tmpinfo = $imginfo;
     $tmpinfo['type'] = $this->src_type;
 
+    $tmpinfo['truecolor'] = true;
+    if($this->src_type == 'GIF')
+    {
+      $tmpinfo['truecolor'] = false;
+    }
+
     // Create empty GD-Object
     $tmp = $this->imageCreateEmpty_GD($tmp, $tmpinfo, true);
 
@@ -2223,26 +2260,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     }
 
     // make sure background is still transparent
-    if(\function_exists('imagecolorallocatealpha'))
-    {
-      // Needs at least php v4.3.2
-      $trnprt_color = \imagecolorallocatealpha($tmp, 0, 0, 0, 127);
-      \imagefill($tmp, 0, 0, $trnprt_color);
-      \imagecolortransparent($tmp, $trnprt_color);
-    }
-    else
-    {
-      $trnprt_indx = \imagecolortransparent($tmp);
-      $palletsize  = \imagecolorstotal($tmp);
-
-      if($trnprt_indx >= 0 && $trnprt_indx < $palletsize)
-      {
-        $trnprt_color = \imagecolorsforindex($tmp, $trnprt_indx);
-        $trnprt_indx  = \imagecolorallocate($tmp, $trnprt_color['red'], $trnprt_color['green'], $trnprt_color['blue']);
-        \imagefill($tmp, 0, 0, $trnprt_indx);
-        \imagecolortransparent($tmp, $trnprt_indx);
-      }
-    }
+    $tmp = $this->keepTransparency_GD($tmp, $wtminfo['truecolor']);
 
     // copy resized watermark on image
     $this->imageCopyMergeAlpha_GD($img_frame, $tmp, 0, 0, 0, 0, $imginfo['width'], $imginfo['height'], $opacity);
@@ -2340,7 +2358,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     return $dst_frame;
   }
 
-    /**
+  /**
    * Same as PHP's imagecopymerge, but works with transparent images. Used internally for overlay.
    * Source: https://github.com/claviska/SimpleImage/blob/93b6df27e1d844a90d52d21a200d91b16371af0f/src/claviska/SimpleImage.php#L482
    *

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -13,7 +13,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 // No direct access
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Filesystem\File;
 use \Joomla\CMS\Filesystem\Path;
 use \Joomla\CMS\Language\Text;
@@ -582,6 +581,12 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
       $this->rollback('', '');
 
       return false;
+    }
+
+    // Add metadata if needed
+    if($this->keep_metadata)
+    {
+      // ToDo: $stream = $this->copyMetadata() using the new metadata service
     }
 
     if(!$base64)

--- a/administrator/com_joomgallery/src/Service/IMGtools/GifCreator.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GifCreator.php
@@ -98,7 +98,7 @@ class GifCreator
   {
     if(!is_array($dst_frames))
     {
-      $this->component->addLog($this->version.': '.$this->errors['ERR00']), 'error', 'jerror');
+      $this->component->addLog($this->version.': '.$this->errors['ERR00'], 'error', 'jerror');
       throw new \Exception($this->version.': '.$this->errors['ERR00']);
     }
 

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -120,6 +120,7 @@ abstract class IMGtools implements IMGtoolsInterface
    protected $dst_imginfo = array('width' => 0,
                                  'height' => 0,
                                  'orientation' => '',
+                                 'ratio' => 1,
                                  'offset_x' => 0,
                                  'offset_y' => 0,
                                  'angle' => 0,
@@ -240,21 +241,7 @@ abstract class IMGtools implements IMGtoolsInterface
     $this->src_type = $imagetype[$info[2]];
 
     // Get the image orientation
-    if($info[0] > $info[1])
-    {
-      $this->res_imginfo['orientation'] = 'landscape';
-    }
-    else
-    {
-      if($info[0] < $info[1])
-      {
-        $this->res_imginfo['orientation'] = 'portrait';
-      }
-      else
-      {
-        $this->res_imginfo['orientation'] = 'square';
-      }
-    }
+    $this->res_imginfo['orientation'] = $this->getOrientation($info[0], $info[1]);
 
     // Detect, if image is a special image
     if($this->src_type == 'PNG')
@@ -476,7 +463,7 @@ abstract class IMGtools implements IMGtoolsInterface
   protected function clearVariables()
   {
     $this->src_imginfo  = array('width' => 0,'height' => 0,'orientation' => '','transparency' => false,'animation' => false, 'frames' => 1);
-    $this->dst_imginfo  = array('width' => 0,'height' => 0,'type' => '','orientation' => '', 'offset_x' => 0,'offset_y' => 0,
+    $this->dst_imginfo  = array('width' => 0,'height' => 0,'type' => '', 'ratio' => 1, 'orientation' => '', 'offset_x' => 0,'offset_y' => 0,
                                'angle' => 0, 'flip' => 'none','quality' => 100,'src' => array('width' => 0,'height' => 0));
     $this->src_frames   = array(array('duration' => 0,'image' => null));
     $this->dst_frames   = array(array('duration' => 0,'image' => null));
@@ -666,7 +653,7 @@ abstract class IMGtools implements IMGtoolsInterface
     if($method != 4)
     {
       // Not cropping
-      $ratio                               = \max($ratio, 1.0);
+      $this->dst_imginfo['ratio'] = $ratio = \max($ratio, 1.0);
       $this->dst_imginfo['width']          = (int)\floor($srcWidth / $ratio);
       $this->dst_imginfo['height']         = (int)\floor($srcHeight / $ratio);
       $this->dst_imginfo['src']['width']   = (int)$srcWidth;
@@ -676,6 +663,7 @@ abstract class IMGtools implements IMGtoolsInterface
     else
     {
       // Cropping
+      $this->dst_imginfo['ratio']         = $ratio;
       $this->dst_imginfo['width']         = (int)$new_width;
       $this->dst_imginfo['height']        = (int)$new_height;
       $this->dst_imginfo['src']['width']  = (int)($this->dst_imginfo['width'] * $ratio);
@@ -781,6 +769,32 @@ abstract class IMGtools implements IMGtoolsInterface
     }
 
     return array($pos_x, $pos_y);
+  }
+
+  /**
+   * Get orientation string based on width and height value
+   *
+   * @param   int      $width    image width
+   * @param   int      $height   image height
+   *
+   * @return  string   Orientation string
+   *
+   * @since   4.0.0
+  */
+  protected function getOrientation($width, $height)
+  {
+    if($width > $height)
+    {
+      return 'landscape';
+    }
+    elseif($height < $width)
+    {
+      return 'portrait';
+    }
+    else
+    {
+      return 'square';
+    }
   }
 
   /**

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -99,6 +99,13 @@ abstract class IMGtools implements IMGtoolsInterface
   protected $metadata = array('exif' => array(),'iptc' => array(),'comment' => array());
 
   /**
+   * Keeps a copy of the initial imginfo arrays
+   *
+   * @var array
+   */
+  protected $ini_imginfo;
+
+  /**
    * Holds all image information of the source image, which are relevant for
    * image processing and metadata handling
    *
@@ -109,6 +116,7 @@ abstract class IMGtools implements IMGtoolsInterface
                                  'orientation' => '',
                                  'transparency' => false,
                                  'animation' => false,
+                                 'truecolor' => true,
                                  'frames' => 1);
 
   /**
@@ -120,6 +128,7 @@ abstract class IMGtools implements IMGtoolsInterface
    protected $dst_imginfo = array('width' => 0,
                                  'height' => 0,
                                  'orientation' => '',
+                                 'truecolor' => true,
                                  'ratio' => 1,
                                  'offset_x' => 0,
                                  'offset_y' => 0,
@@ -138,6 +147,7 @@ abstract class IMGtools implements IMGtoolsInterface
                                  'orientation' => '',
                                  'transparency' => false,
                                  'animation' => false,
+                                 'truecolor' => true,
                                  'frames' => 1);
   
   /**
@@ -158,10 +168,12 @@ abstract class IMGtools implements IMGtoolsInterface
     // Load component
     $this->getComponent();
 
-    $this->keep_metadata = $keep_metadata;
-    $this->keep_anim     = $keep_anim;
-
+    $this->keep_metadata   = $keep_metadata;
+    $this->keep_anim       = $keep_anim;
     $this->supported_types = $this->getTypes();
+
+    // Backup the imginfo arrays
+    $this->ini_imginfo = array('src' => $this->src_imginfo, 'dst' => $this->dst_imginfo, 'res' => $this->res_imginfo);
   }
 
   /**
@@ -209,7 +221,7 @@ abstract class IMGtools implements IMGtoolsInterface
         $string_stream = $img;
       }
       
-      $info       = \getimagesizefromstring($string_stream);
+      $info = \getimagesizefromstring($string_stream);
     }
     else
     {
@@ -246,6 +258,13 @@ abstract class IMGtools implements IMGtoolsInterface
     // Detect, if image is a special image
     if($this->src_type == 'PNG')
     {
+      // Detect if png is based on palettes
+      $included = \strpos(\file_get_contents($img), "PLTE");
+      if($included !== false)
+      {
+        $this->res_imginfo['truecolor'] = false;
+      }
+
       // Detect, if png has transparency
       if($is_stream)
       {
@@ -273,15 +292,25 @@ abstract class IMGtools implements IMGtoolsInterface
       else
       {
         $webptype = \file_get_contents($img);
+
+        // Detect if webp is based on palettes
+        $included = \strpos($webptype, "VP8L");
+        if($included !== false)
+        {
+          // The VP8L signature which indicates lossless WebP that might use a palette
+          $this->res_imginfo['truecolor'] = false;
+        }
+
+        // Detect if webp is transparent
         $included = \strpos($webptype, "ALPH");
-        if($included !== FALSE)
+        if($included !== false)
         {
           $this->res_imginfo['transparency'] = true;
         }
         else
         {
           $included = \strpos($webptype, "VP8L");
-          if($included !== FALSE)
+          if($included !== false)
           {
             $this->res_imginfo['transparency'] = true;
           }
@@ -289,14 +318,14 @@ abstract class IMGtools implements IMGtoolsInterface
 
         // Detect, if webp has animation
         $included = \strpos($webptype, "ANIM");
-        if($included !== FALSE)
+        if($included !== false)
         {
           $this->res_imginfo['animation'] = true;
         }
         else
         {
           $included = \strpos($webptype, "ANMF");
-          if($included !== FALSE)
+          if($included !== false)
           {
             $this->res_imginfo['animation'] = true;
           }
@@ -314,6 +343,9 @@ abstract class IMGtools implements IMGtoolsInterface
 
     if($this->src_type == 'GIF')
     {
+      // GIF is never truecolor
+      $this->res_imginfo['truecolor'] = false;
+
       // Detect, if gif is animated
       $count = 0;
       if(!$is_stream)
@@ -456,17 +488,41 @@ abstract class IMGtools implements IMGtoolsInterface
   /**
    * Clears the class variables and bring it back to default
    *
-   * @return  boolean   true on success, false otherwise
+   * @return  void
    *
    * @since   3.5.0
   */
   protected function clearVariables()
   {
-    $this->src_imginfo  = array('width' => 0,'height' => 0,'orientation' => '','transparency' => false,'animation' => false, 'frames' => 1);
-    $this->dst_imginfo  = array('width' => 0,'height' => 0,'type' => '', 'ratio' => 1, 'orientation' => '', 'offset_x' => 0,'offset_y' => 0,
-                               'angle' => 0, 'flip' => 'none','quality' => 100,'src' => array('width' => 0,'height' => 0));
+    // Clear the imginfo arrays
+    $this->clearImginfo(\array_keys($this->ini_imginfo));
+
+    // Clear the frames
     $this->src_frames   = array(array('duration' => 0,'image' => null));
     $this->dst_frames   = array(array('duration' => 0,'image' => null));
+  }
+
+  /**
+   * Clears the class variables and bring it back to default
+   * 
+   * @param   string|array  $key  The name of the imginfo array to be cleared
+   *
+   * @return  void
+   *
+   * @since   4.0.0
+  */
+  protected function clearImginfo($key)
+  {
+    if(!\is_array($key))
+    {
+      $key = array($key);
+    }
+
+    foreach ($key as $kval)
+    {
+      $name = $kval . '_imginfo';
+      $this->{$name} = $this->ini_imginfo[$kval];
+    }    
   }
 
   /**
@@ -670,6 +726,9 @@ abstract class IMGtools implements IMGtoolsInterface
       $this->dst_imginfo['src']['height'] = (int)($this->dst_imginfo['height'] * $ratio);
     }
 
+    // Preserve information about truecolor
+    $this->dst_imginfo['truecolor'] = $this->src_imginfo['truecolor'];
+
     return true;
   }
 
@@ -767,6 +826,9 @@ abstract class IMGtools implements IMGtoolsInterface
         $pos_y = 0;
         break;
     }
+
+    // Preserve information about truecolor
+    $this->dst_imginfo['truecolor'] = $this->src_imginfo['truecolor'];
 
     return array($pos_x, $pos_y);
   }

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -878,6 +878,11 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
 
     $this->auto_orient = true;
 
+    if(isset($this->metadata['exif']['IFD0']['Orientation']))
+    {
+      $this->autoOrient($this->metadata['exif']['IFD0']['Orientation']);
+    }
+
     return true;
   }
 

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -333,7 +333,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     // assemble the shell command
     $convert = $this->assemble($file);
 
-    // strip [0] from src_file
+    /// Remove '[0]' from src_file
     $this->src_file = \str_replace('[0]','',$this->src_file);
 
     $return_var = null;
@@ -420,7 +420,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     $this->clearVariables();
 
     return true;
-  } 
+  }
 
   /**
    * Output the image as string (stream)
@@ -454,6 +454,14 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
       $this->dst_type = $this->src_type;
     }
 
+    // Temporary remove '[0]' from src_file
+    $first_frame_only = false;
+    if(\strpos($this->src_file, '[0]') !== false)
+    {
+      $this->src_file = \str_replace('[0]','',$this->src_file);
+      $first_frame_only = true;
+    }    
+
     // Define temporary image file to be created
     $tmp_folder   = $this->app->get('tmp_path');
     $tmp_dst_file = $tmp_folder.'/tmp_dst_img_'.$this->rndNumber.'.'.\strtolower($this->dst_type);
@@ -478,6 +486,13 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     
     // Redefine scr_file variable
     $this->src_file = $tmp_src_file;
+
+    // Select only first frame if to not keep animation
+    if($first_frame_only)
+    {
+      // If resizing an animation but not preserving the animation, consider only first frame
+      $this->onlyFirstFrame();
+    }
 
     if(!$this->write($tmp_dst_file, $quality))
     {


### PR DESCRIPTION
This PR fixes different upload issues reported in the issue tracker of this repository. The following issues have been fixed:

- #107
- #111 
- #118 
- #130 
- #262 

The issus reported in 111 & 118 are only partially solved. In case there is no image processing configured, the original image gets now copied and no changes will be made on it. This ensures that matadata is prevented and filesize is not changed. In case there are any image processing settings set on the original image, this issues still exist.

But at least for issue 111, the metadata service currently beeing developed by @Spoicy will have a fix for that.

### How to test this PR
Upload multiple different images (different file types like jpg, png, gif, webp). Use some with tarnsparency and some with animations. Test both image processors, Imagemagick and GD. Use jpg images with matadata and look if the images are rotated correctly and if the replacement with metadata works.
Test out different image processing settings and check if the problems reported in the different issues are gone and no new ones were introduced.

I know, this is quite a lot. But this PR changes multiple things on the hearth of our component, the IMGtools service. Good and proper image processing is what makes the difference between JoomGallery and any other gallery application out there. While most galleries only provide very limited image processing possibilities JoomGallery provides a lot of functionality here.

Thanks to @szepty-ziemi who helped me testing this service in its early days and helped me create such a robust and function reach image processing service!