### PR TITLE
Access check for frontend views

### DIFF
--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -40,6 +40,12 @@ class RawView extends JoomGalleryView
     $type = $this->app->input->get('type', 'thumbnail', 'word');
     $id   = $this->app->input->get('id', 0, 'int');
 
+    // Check access
+    if(!$this->access($id))
+    {
+      $this->app->redirect(Route::_('index.php', false), 403);
+    } 
+
     // Get image path
     $img_path = JoomHelper::getImg($id, $type, false, false);
 
@@ -95,6 +101,18 @@ class RawView extends JoomGalleryView
 	 * @return  bool       True on success, false otherwise
 	 */
   public function ppImage(&$file_info, &$resource, $imagetype)
+  {
+    return true;
+  }
+
+  /**
+	 * Check access to this image
+	 *
+	 * @param   int  $id    Iamge id
+	 *
+	 * @return   bool    True on success, false otherwise
+	 */
+  protected function access($id)
   {
     return true;
   }

--- a/site/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/site/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -92,6 +92,7 @@ COM_JOOMGALLERY_ACTION_IMAGE_EDITSTATE_DESC="Allow users in the group to edit im
 COM_JOOMGALLERY_ACTION_IMAGE_EDIT_DESC="Allow users in the group to edit images."
 COM_JOOMGALLERY_ACTION_IMAGE_DELETE_OWN_DESC="Allow users in the group to delete their own images."
 COM_JOOMGALLERY_ERROR_ACCESS_VIEW="You don't have permission to access this view."
+COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW="The view you requested is not available."
 
 ;Toolbar
 COM_JOOMGALLERY_USER_GROUP_ASC="User Group ascending"

--- a/site/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/site/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -93,6 +93,7 @@ COM_JOOMGALLERY_ACTION_IMAGE_EDIT_DESC="Allow users in the group to edit images.
 COM_JOOMGALLERY_ACTION_IMAGE_DELETE_OWN_DESC="Allow users in the group to delete their own images."
 COM_JOOMGALLERY_ERROR_ACCESS_VIEW="You don't have permission to access this view."
 COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW="The view you requested is not available."
+COM_JOOMGALLERY_ERROR_IMAGE_CAT_PROTECTED="The image you requested is within a protected category. You need to unlock the category first before accessing this image."
 
 ;Toolbar
 COM_JOOMGALLERY_USER_GROUP_ASC="User Group ascending"

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -598,4 +598,166 @@ class CategoryModel extends JoomItemModel
 
     return $fields;
   }
+
+  /**
+   * Get a list of parent categories that are not published (state = 1)
+   * 
+   * @param   int    $pk         Primary key of the category
+   * @param   bool   $approved   True if the parents also have to be approved
+   *
+   * @return  array  List of all parents that are published
+   *
+   * @since   4.0.0
+   * @throws Exception
+   */
+  public function getUnpublishedParents(int $pk = null, bool $approved = false): array
+  {
+    if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
+    {
+      $pk = \intval($this->item->id);
+    }
+    else
+    {
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
+    }
+
+    // Create a new query object.
+		$db    = $this->getDbo();
+		$query = $db->getQuery(true);
+    $query->select('id');
+    $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+
+    // Select parents
+    $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
+
+    // Exclude root category
+    $query->where($db->quoteName('level') . ' > 0');
+
+    if($approved)
+    {
+      // Select records which are not published or not approved
+      $query->where('(' . $db->quoteName('published') . ' != 1 OR ' . $db->quoteName('approved') . ' != 1)');
+    }
+    else
+    {
+      // Select records which are not published
+      $query->where($db->quoteName('published') . ' != 1');
+    }
+
+    try
+    {
+      $db->setQuery($query);
+      $list = $db->loadColumn();
+    }
+    catch(\Exception $e)
+    {
+      $this->setError($e->getMessage());
+      $this->component->addLog('Error in getAncestorIsPublished(). Error: ' . $e->getMessage(), 'error', 'jerror');
+
+      return [];
+    }
+
+    return $list ? $list : [];
+  }
+
+  /**
+   * Get a list of parent categories that are are protected
+   *
+   * @return  array  List of all parents that are protected
+   *
+   * @since   4.0.0
+   */
+  public function getProtectedParents(int $pk = null): array
+  {
+    if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
+    {
+      $pk = \intval($this->item->id);
+    }
+    else
+    {
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
+    }
+
+    // Create a new query object.
+		$db    = $this->getDbo();
+		$query = $db->getQuery(true);
+    $query->select('id');
+    $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+
+    // Select parents
+    $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
+
+    // Exclude root category
+    $query->where($db->quoteName('level') . ' > 0');
+
+    // Select records which are protected and not yet unlocked
+    $query->where('(' . $db->quoteName('password') . ' != ' . $db->quote('') . ' AND ' . $db->quoteName('id') . ' NOT IN (' . implode(',', $this->app->getUserState(_JOOM_OPTION.'unlockedCategories', array(0))) . '))');
+
+    try
+    {
+      $db->setQuery($query);
+      $list = $db->loadColumn();
+    }
+    catch(\Exception $e)
+    {
+      $this->setError($e->getMessage());
+      $this->component->addLog('Error in getAncestorIsProtected(). Error: ' . $e->getMessage(), 'error', 'jerror');
+
+      return [];
+    }
+
+    return $list ? $list : [];
+  }
+
+  /**
+   * Get a list of parent categories that are not accessible (view level) by the user
+   *
+   * @return  array  List of all parents that are not accessible
+   *
+   * @since   4.0.0
+   */
+  public function getAccessibleParents(int $pk = null): array
+  {
+    if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
+    {
+      $pk = \intval($this->item->id);
+    }
+    else
+    {
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
+    }
+
+    // Get current user
+    $user  = $this->app->getIdentity();
+
+    // Create a new query object.
+		$db    = $this->getDbo();
+		$query = $db->getQuery(true);
+    $query->select('id');
+    $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+
+    // Select parents
+    $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
+
+    // Exclude root category
+    $query->where($db->quoteName('level') . ' > 0');
+
+    // Select records which are not accessible via users view levels
+    $query->where($db->quoteName('access') . ' NOT IN (' . implode(',', $user->getAuthorisedViewLevels()) . ')');
+
+    try
+    {
+      $db->setQuery($query);
+      $list = $db->loadColumn();
+    }
+    catch(\Exception $e)
+    {
+      $this->setError($e->getMessage());
+      $this->component->addLog('Error in getAncestorIsViewLevel(). Error: ' . $e->getMessage(), 'error', 'jerror');
+
+      return [];
+    }
+
+    return $list ? $list : [];
+  }
 }

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -108,13 +108,13 @@ class CategoryModel extends JoomItemModel
 		}
 
 		// Add created by name
-		if(isset($this->item->created_by))
+		if(isset($this->item->created_by) && !isset($this->item->created_by_name))
 		{
 			$this->item->created_by_name = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($this->item->created_by)->name;
 		}
 
 		// Add modified by name
-		if(isset($this->item->modified_by))
+		if(isset($this->item->modified_by) && !isset($this->item->modified_by_name))
 		{
 			$this->item->modified_by_name = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($this->item->modified_by)->name;
 		}
@@ -621,11 +621,17 @@ class CategoryModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
     }
 
+    if(isset($this->item->unpublishedParents))
+    {
+      return $this->item->unpublishedParents;
+    }
+
     // Create a new query object.
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+    $query->order($db->quoteName('level') . ' DESC');
 
     // Select parents
     $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
@@ -657,7 +663,9 @@ class CategoryModel extends JoomItemModel
       return [];
     }
 
-    return $list ? $list : [];
+    $this->item->unpublishedParents = $list ? $list : [];
+
+    return $this->item->unpublishedParents;
   }
 
   /**
@@ -678,11 +686,17 @@ class CategoryModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
     }
 
+    if(isset($this->item->protectedParents))
+    {
+      return $this->item->protectedParents;
+    }
+
     // Create a new query object.
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+    $query->order($db->quoteName('level') . ' DESC');
 
     // Select parents
     $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
@@ -706,7 +720,9 @@ class CategoryModel extends JoomItemModel
       return [];
     }
 
-    return $list ? $list : [];
+    $this->item->protectedParents = $list ? $list : [];
+
+    return $this->item->protectedParents;
   }
 
   /**
@@ -727,6 +743,11 @@ class CategoryModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);      
     }
 
+    if(isset($this->item->accessibleParents))
+    {
+      return $this->item->accessibleParents;
+    }
+
     // Get current user
     $user  = $this->app->getIdentity();
 
@@ -735,6 +756,7 @@ class CategoryModel extends JoomItemModel
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
+    $query->order($db->quoteName('level') . ' DESC');
 
     // Select parents
     $query->where($db->quoteName('lft') . ' <= ' . $this->item->lft . ' AND ' . $db->quoteName('rgt') . ' >= ' . $this->item->rgt);
@@ -758,6 +780,8 @@ class CategoryModel extends JoomItemModel
       return [];
     }
 
-    return $list ? $list : [];
+    $this->item->accessibleParents = $list ? $list : [];
+
+    return $this->item->accessibleParents;
   }
 }

--- a/site/com_joomgallery/src/Model/ImageModel.php
+++ b/site/com_joomgallery/src/Model/ImageModel.php
@@ -34,6 +34,14 @@ class ImageModel extends JoomItemModel
   protected $type = 'image';
 
 	/**
+   * Category item object
+   *
+   * @access  protected
+   * @var     object
+   */
+  protected $category = null;
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.
@@ -140,18 +148,85 @@ class ImageModel extends JoomItemModel
 	 */
   protected function getCategoryName(int $catid)
   {
-    // Create a new query object.
-		$db    = $this->getDbo();
-		$query = $db->getQuery(true);
+		if(!$catid && $this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
 
-    // Select the required field from the table.
-		$query->select($db->quoteName('title'));
-    $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES))
-          ->where($db->quoteName('id') . " = " . $db->quote($catid));
+		// Get id
+		$catid = $catid ? $catid : $this->item->catid; 
 
-    // Reset the query using our newly populated query object.
-    $db->setQuery($query);
-    
-    return $db->loadResult();
+		if(!$this->category || !$this->category->id == $catid)
+		{
+			// Create model
+			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+
+			// Load category
+			$this->category = $catModel->getItem($catid);
+		}		
+
+		return $this->category->title;
   }
+
+	/**
+	 * Method to check if the category is protected
+	 *
+	 * @param   int  $catid  Category id
+	 *
+	 * @return  bool  True if category is protected, false otherwise
+	 * 
+	 * @throws \Exception
+	 */
+	public function getCategoryProtected(int $catid = 0)
+	{
+		if(!$catid && $this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+		// Get id
+		$catid = $catid ? $catid : $this->item->catid; 
+
+		if(!$this->category || !$this->category->id == $catid)
+		{
+			// Create model
+			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+
+			// Load category
+			$this->category = $catModel->getItem($catid);
+		}		
+
+		return $this->category->pw_protected;
+	}
+
+	/**
+	 * Method to check if the category is published
+	 *
+	 * @param   int  $catid  Category id
+	 *
+	 * @return  bool  True if category is protected, false otherwise
+	 * 
+	 * @throws \Exception
+	 */
+	public function getCategoryPublished(int $catid = 0)
+	{
+		if(!$catid && $this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+		// Get id
+		$catid = $catid ? $catid : $this->item->catid; 
+
+		if(!$this->category || !$this->category->id == $catid)
+		{
+			// Create model
+			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+
+			// Load category
+			$this->category = $catModel->getItem($catid);
+		}
+
+		return $this->category->published == 1;
+	}
 }

--- a/site/com_joomgallery/src/Model/ImageModel.php
+++ b/site/com_joomgallery/src/Model/ImageModel.php
@@ -34,7 +34,7 @@ class ImageModel extends JoomItemModel
   protected $type = 'image';
 
 	/**
-   * Category item object
+   * Category model
    *
    * @access  protected
    * @var     object
@@ -154,18 +154,18 @@ class ImageModel extends JoomItemModel
     }
 
 		// Get id
-		$catid = $catid ? $catid : $this->item->catid; 
+		$catid = $catid ? $catid : $this->item->catid;
 
-		if(!$this->category || !$this->category->id == $catid)
+		if(!$this->category)
 		{
 			// Create model
-			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+			$this->category = $this->component->getMVCFactory()->createModel('category', 'site');		
+		}
 
-			// Load category
-			$this->category = $catModel->getItem($catid);
-		}		
+		// Load category
+		$cat_item = $this->category->getItem($catid);
 
-		return $this->category->title;
+		return $cat_item->title;
   }
 
 	/**
@@ -184,19 +184,24 @@ class ImageModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
     }
 
-		// Get id
-		$catid = $catid ? $catid : $this->item->catid; 
-
-		if(!$this->category || !$this->category->id == $catid)
+		if(!isset($this->item->protectedParents))
 		{
-			// Create model
-			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+			// Get id
+			$catid = $catid ? $catid : $this->item->catid;
+
+			if(!$this->category)
+			{
+				// Create model
+				$this->category = $this->component->getMVCFactory()->createModel('category', 'site');
+			}
 
 			// Load category
-			$this->category = $catModel->getItem($catid);
+			$this->category->getItem($catid);
+			
+			$this->item->protectedParents = $this->category->getProtectedParents();
 		}
 
-		return empty($catModel->getProtectedParents());
+		return !empty($this->item->protectedParents);
 	}
 
 	/**
@@ -215,19 +220,24 @@ class ImageModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
     }
 
-		// Get id
-		$catid = $catid ? $catid : $this->item->catid; 
-
-		if(!$this->category || !$this->category->id == $catid)
+		if(!isset($this->item->unpublishedParents))
 		{
-			// Create model
-			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+			// Get id
+			$catid = $catid ? $catid : $this->item->catid;
+
+			if(!$this->category)
+			{
+				// Create model
+				$this->category = $this->component->getMVCFactory()->createModel('category', 'site');
+			}
 
 			// Load category
-			$this->category = $catModel->getItem($catid);
+			$this->category->getItem($catid);
+
+			$this->item->unpublishedParents = $this->category->getUnpublishedParents(null, $approved);
 		}
 
-		return empty($catModel->getUnpublishedParents(null, $approved));
+		return empty($this->item->unpublishedParents);
 	}
 
   /**
@@ -246,18 +256,23 @@ class ImageModel extends JoomItemModel
       throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
     }
 
-		// Get id
-		$catid = $catid ? $catid : $this->item->catid; 
-
-		if(!$this->category || !$this->category->id == $catid)
+		if(!isset($this->item->accessibleParents))
 		{
-			// Create model
-			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+			// Get id
+			$catid = $catid ? $catid : $this->item->catid;
+
+			if(!$this->category)
+			{
+				// Create model
+				$this->category = $this->component->getMVCFactory()->createModel('category', 'site');
+			}
 
 			// Load category
-			$this->category = $catModel->getItem($catid);
+			$this->category->getItem($catid);
+
+			$this->item->accessibleParents = $this->category->getAccessibleParents();
 		}
 
-		return empty($catModel->getAccessibleParents());
+		return empty($this->item->accessibleParents);
 	}
 }

--- a/site/com_joomgallery/src/Model/ImageModel.php
+++ b/site/com_joomgallery/src/Model/ImageModel.php
@@ -169,11 +169,11 @@ class ImageModel extends JoomItemModel
   }
 
 	/**
-	 * Method to check if the category is protected
+	 * Method to check if any parent category is protected
 	 *
 	 * @param   int  $catid  Category id
 	 *
-	 * @return  bool  True if category is protected, false otherwise
+	 * @return  bool  True if categories are protected, false otherwise
 	 * 
 	 * @throws \Exception
 	 */
@@ -194,21 +194,21 @@ class ImageModel extends JoomItemModel
 
 			// Load category
 			$this->category = $catModel->getItem($catid);
-		}		
+		}
 
-		return $this->category->pw_protected;
+		return empty($catModel->getProtectedParents());
 	}
 
 	/**
-	 * Method to check if the category is published
+	 * Method to check if all parent categories are published
 	 *
 	 * @param   int  $catid  Category id
 	 *
-	 * @return  bool  True if category is protected, false otherwise
+	 * @return  bool  True if all categories are published, false otherwise
 	 * 
 	 * @throws \Exception
 	 */
-	public function getCategoryPublished(int $catid = 0)
+	public function getCategoryPublished(int $catid = 0, bool $approved = false)
 	{
 		if(!$catid && $this->item === null)
 		{
@@ -227,6 +227,37 @@ class ImageModel extends JoomItemModel
 			$this->category = $catModel->getItem($catid);
 		}
 
-		return $this->category->published == 1;
+		return empty($catModel->getUnpublishedParents(null, $approved));
+	}
+
+  /**
+	 * Method to check if all parent categories are accessible (view levels)
+	 *
+	 * @param   int  $catid  Category id
+	 *
+	 * @return  bool  True if all categories are accessible, false otherwise
+	 * 
+	 * @throws \Exception
+	 */
+	public function getCategoryAccess(int $catid = 0)
+	{
+		if(!$catid && $this->item === null)
+		{
+      throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 1);
+    }
+
+		// Get id
+		$catid = $catid ? $catid : $this->item->catid; 
+
+		if(!$this->category || !$this->category->id == $catid)
+		{
+			// Create model
+			$catModel = $this->component->getMVCFactory()->createModel('category', 'site');		
+
+			// Load category
+			$this->category = $catModel->getItem($catid);
+		}
+
+		return empty($catModel->getAccessibleParents());
 	}
 }

--- a/site/com_joomgallery/src/View/Category/JsonView.php
+++ b/site/com_joomgallery/src/View/Category/JsonView.php
@@ -42,13 +42,28 @@ class JsonView extends JoomGalleryJsonView
 	{
     // Current category item
 		$this->state  = $this->get('State');
-		$this->item   = $this->get('Item');
+
+    $loaded = true;
+		try {
+			$this->item = $this->get('Item');
+		}
+		catch (\Exception $e)
+		{
+			$loaded = false;
+		}
+
+    // Check published state
+		if($loaded && $this->item->published !== 1) 
+		{
+			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
+			return;
+		}
 
     // Check acces view level
 		if(!\in_array($this->item->access, $this->user->getAuthorisedViewLevels()))
     {
       $this->output(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'));
-      $this->error = true;
+      return;
     }
 
     // Load parent category

--- a/site/com_joomgallery/src/View/Category/RawView.php
+++ b/site/com_joomgallery/src/View/Category/RawView.php
@@ -23,5 +23,29 @@ use \Joomgallery\Component\Joomgallery\Administrator\View\Category\RawView as Ad
  */
 class RawView extends AdminRawView
 {
-  // Use the RawView class from administrator application
+  /**
+	 * Display the category image
+	 *
+	 * @param   string  $tpl  Template name
+	 *
+	 * @return void
+	 */
+	public function display($tpl = null)
+	{
+    parent::display($tpl);
+
+    // Check published state
+		if($this->item->id && $this->item->published !== 1) 
+		{
+			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
+			return;
+		}
+
+    // Check acces view level
+		if(!\in_array($this->item->access, $this->user->getAuthorisedViewLevels()))
+    {
+      $this->output(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'));
+      return;
+    }
+  }
 }

--- a/site/com_joomgallery/src/View/Categoryform/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categoryform/HtmlView.php
@@ -77,25 +77,27 @@ class HtmlView extends JoomGalleryView
 			return;
 		}
 		
+		// Load state and params
 		$this->state  = $this->get('State');
 		$this->params = $this->get('Params');
 		$this->item   = $this->get('Item');
 		$this->form		= $this->get('Form');
 
     // Get return page
-    $this->return_page = $this->get('ReturnPage');
-
-		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
-		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
-		}
+    $this->return_page = $this->get('ReturnPage');		
 
     // Check acces view level
 		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
     {
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
+			return;
     }
+		
+		// Check for errors.
+		if(\count($errors = $this->get('Errors')))
+		{
+			throw new GenericDataException(\implode("\n", $errors), 500);
+		}
 
 		$this->_prepareDocument();
 

--- a/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -66,12 +66,16 @@ class HtmlView extends JoomGalleryView
 			$loaded = false;
 		}
 
+		$temp = $this->get('CategoryProtected');
+
 		// Check if category is protected?
 		if($loaded && $this->get('CategoryProtected'))
 		{
 			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_IMAGE_CAT_PROTECTED'), 'error');
-			$this->app->redirect(Route::_('index.php?option='._JOOM_OPTION.'&view=category&id='.$this->item->catid));
+			$this->app->redirect(Route::_('index.php?option='._JOOM_OPTION.'&view=category&id='.$this->item->protectedParents[0]));
 		}
+
+		$temp = $this->get('CategoryPublished');
 
 		// Check published and approved state
 		if(!$loaded || !$this->get('CategoryPublished') ||$this->item->published !== 1 || $this->item->approved !== 1)
@@ -79,6 +83,8 @@ class HtmlView extends JoomGalleryView
 			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
 			return;
 		}
+
+		$temp = $this->get('CategoryAccess');
 
     // Check acces view level
 		if(!$this->get('CategoryAccess') || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))

--- a/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -73,7 +73,7 @@ class HtmlView extends JoomGalleryView
 			$this->app->redirect(Route::_('index.php?option='._JOOM_OPTION.'&view=category&id='.$this->item->catid));
 		}
 
-		// Check published state
+		// Check published and approved state
 		if(!$loaded || !$this->get('CategoryPublished') ||$this->item->published !== 1 || $this->item->approved !== 1)
 		{
 			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
@@ -81,7 +81,7 @@ class HtmlView extends JoomGalleryView
 		}
 
     // Check acces view level
-		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+		if(!$this->get('CategoryAccess') || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
     {
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
 			return;

--- a/site/com_joomgallery/src/View/Image/JpgView.php
+++ b/site/com_joomgallery/src/View/Image/JpgView.php
@@ -13,15 +13,13 @@ namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 // No direct access
 defined('_JEXEC') or die;
 
-use \Joomgallery\Component\Joomgallery\Administrator\View\Image\RawView as AdminRawView;
-
 /**
  * Raw view class for a single Image.
  * 
  * @package JoomGallery
  * @since   4.0.0
  */
-class JpgView extends AdminRawView
+class JpgView extends RawView
 {
   // Use the RawView class from administrator application
 }

--- a/site/com_joomgallery/src/View/Image/RawView.php
+++ b/site/com_joomgallery/src/View/Image/RawView.php
@@ -26,6 +26,13 @@ use \Joomgallery\Component\Joomgallery\Administrator\View\Image\RawView as Admin
 class RawView extends AdminRawView
 {
   /**
+	 * The media object
+	 *
+	 * @var  \stdClass
+	 */
+	protected $item;
+
+  /**
 	 * Postprocessing the image after retrieving the image ressource
 	 *
 	 * @param   \stdClass  $file_info    Object with file information
@@ -160,5 +167,46 @@ class RawView extends AdminRawView
     }
 
     return true;
+  }
+
+  /**
+	 * Check access to this image
+	 *
+	 * @param   int  $id    Iamge id
+	 *
+	 * @return   bool    True on success, false otherwise
+	 */
+  protected function access($id)
+  {
+    $loaded = true;
+    $access = true;
+
+		try {
+			$this->item = $this->get('Item');
+		}
+		catch (\Exception $e)
+		{
+			$loaded = false;
+		}
+
+    // Check if category is protected?
+		if($loaded && $this->get('CategoryProtected'))
+		{
+      $access = false;
+		}
+
+    // Check published state
+		if(!$loaded || !$this->get('CategoryPublished') ||$this->item->published !== 1 || $this->item->approved !== 1)
+		{
+			$access = false;
+		}
+
+    // Check acces view level
+		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+    {
+      $access = false;
+    }
+
+    return $access;
   }
 }

--- a/site/com_joomgallery/src/View/Image/RawView.php
+++ b/site/com_joomgallery/src/View/Image/RawView.php
@@ -196,13 +196,13 @@ class RawView extends AdminRawView
 		}
 
     // Check published state
-		if(!$loaded || !$this->get('CategoryPublished') ||$this->item->published !== 1 || $this->item->approved !== 1)
+		if(!$loaded || !$this->get('CategoryPublished') || $this->item->published !== 1 || $this->item->approved !== 1)
 		{
 			$access = false;
 		}
 
     // Check acces view level
-		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+		if(!$this->get('CategoryAccess') || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
     {
       $access = false;
     }


### PR DESCRIPTION
This PR solves the issue reported in #294 

The following frontend views are affected:
- category (format: html, json, raw)
  URL: option=com_joomgallery&view=category&id=<catid>&format=html
- image (format: html, raw)
  URL: option=com_joomgallery&view=category&id=<imgid&format=html

## What has changed

In the category view it gets checked, that
- the category is published
- the user has the proper access level for this category
- the category is protected with a password

In the image view it gets checked, that
- the category is published
- the category is protected with a password
- the image is published
- the image is approved
- the user has the proper access level for this image

Images and categories of a protected category can be accessed, even if the password of the parent category is not validated. @MrMusic does this behavior correspond to the JG3 behavior? Is this behavior in general good enough?
Because to check all parent categories up to the root is quite difficult to implement.

## How to test this PR
Accessing views in the fronted using direct urls in the browser address line.
In parallel open the images and categories administrator tables and change different settings (approved, published, access, password). Check everytime in the frontend, whether the behavior corresponds to the expected behavior. When accessing an unaccessible item, there should be an error message displayed (at least in the html views).