### PR TITLE
Layouts for Category view

### DIFF
--- a/media/com_joomgallery/joomla.asset.json
+++ b/media/com_joomgallery/joomla.asset.json
@@ -134,6 +134,11 @@
       }
     },
     {
+      "name": "com_joomgallery.joomgrid",
+      "type": "script",
+      "uri": "com_joomgallery/joomgrid.js"
+    },
+    {
       "name": "com_joomgallery.uppy-uploader",
       "type": "script",
       "uri": "com_joomgallery/uppy/dist/uppy-uploader.js",

--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -1,0 +1,164 @@
+// Initialisation
+const defaults = {
+        itemid : 1,
+        pagination: 1,
+        layout: 'masonry',
+        num_columns: 3,
+        lightbox: false,
+        lightboxes: {},
+        imgboxclass: 'jg-image',
+        imgclass: 'jg-image-thumb',
+        gridclass: 'jg-category',
+        infscrollclass: 'infinite-scroll',
+        loadmoreid: 'loadMore',
+        loaderclass: 'jg-loader',
+        justifieds: {},
+        justified: {height: 320, gap: 5}
+};
+
+// Ensure window.joomGrid exists
+window.joomGrid = window.joomGrid || {};
+
+// Loop through defaults and check against window.joomGrid
+for(const [key, value] of Object.entries(defaults)) {
+  if(!window.joomGrid.hasOwnProperty(key) || window.joomGrid[key] === undefined || window.joomGrid[key] === null) {
+    window.joomGrid[key] = value;
+  }
+}
+
+var callback = function() {
+  // Get the grid container
+  const grid = document.querySelector('.' + window.joomGrid.gridclass);
+
+  // Initialize lightGallery
+  if(window.joomGrid.lightbox) {
+    const lightbox = document.getElementById('lightgallery-' + window.joomGrid.id);
+
+    window.joomGrid.lightboxes[window.joomGrid.itemid] = lightGallery(lightbox, {
+      selector: '.lightgallery-item',
+      // allowMediaOverlap: true,
+      thumbHeight: '50px',
+      thumbMargin: 5,
+      thumbWidth: 75,
+      thumbnail: true,
+      toggleThumb: true,
+      speed: 500,
+      plugins: [lgThumbnail],
+      preload: 1,
+      loop: false,
+      counter: true,
+      download: false,
+      mobileSettings: {
+        controls: false,
+        showCloseIcon: true,
+        download: false,
+      },
+      licenseKey: '1111-1111-111-1111',
+    });
+    
+    if(lightbox) {
+      window.joomGrid.lightboxes[window.joomGrid.itemid].outer.on('click', (e) => {
+        const $item = window.joomGrid.lightboxes[window.joomGrid.itemid].outer.find('.lg-current .lg-image');
+        if (
+          e.target.classList.contains('lg-image') ||
+          $item.get().contains(e.target)
+        ) {
+          window.joomGrid.lightboxes[window.joomGrid.itemid].goToNextSlide();
+        }
+      });
+    }
+  }
+
+  // Load justified for grid selected by gridclass (category images)
+  if(window.joomGrid.layout == 'justified') {
+    const imgs = document.querySelectorAll('.' + window.joomGrid.gridclass + ' img');
+    const options = {
+      idealHeight: window.joomGrid.justified.height,
+      maxRowImgs: 32,
+      rowGap: window.joomGrid.justified.gap,
+      columnGap: window.joomGrid.justified.gap,
+    };
+    window.joomGrid.justifieds[window.joomGrid.itemid] = new ImgJust(grid, imgs, options);
+  }
+
+  // Infinity scroll or load more
+  if(window.joomGrid.pagination == 1 || window.joomGrid.pagination == 2)
+  {
+    const items        = Array.from(grid.getElementsByClassName(window.joomGrid.imgboxclass));
+    const maxImages    = window.joomGrid.num_columns * 2;
+    const loadImages   = window.joomGrid.num_columns * 3;
+    const hiddenClass  = 'hidden-' + window.joomGrid.imgboxclass;
+    const hiddenImages = Array.from(document.getElementsByClassName(hiddenClass));
+
+    items.forEach(function (item, index) {
+      if (index > maxImages - 1) {
+        item.classList.add(hiddenClass);
+      }
+    });
+
+    if(window.joomGrid.pagination == 1) {
+      // Infinity scroll
+      const observerOptions = {
+        root: null,
+        rootMargin: '200px',
+        threshold: 0
+      };
+      
+      function observerCallback(entries, observer) {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
+              item,
+              index
+            ) {
+              if (index < loadImages) {
+                item.classList.remove(hiddenClass);
+              }
+              if (document.querySelectorAll('.' + hiddenClass).length === 0) {
+                noMore.classList.remove('hidden');
+              }
+            });
+          }
+        });
+      }
+      
+      const fadeElms = document.querySelectorAll('.' + window.joomGrid.infscrollclass);
+      const observer = new IntersectionObserver(observerCallback, observerOptions);
+      fadeElms.forEach(el => observer.observe(el));
+    } else if(window.joomGrid.pagination == 2) {
+      // Load more button
+      const loadMore = document.getElementById(window.joomGrid.loadmoreid);
+  
+      loadMore.addEventListener('click', function () {
+        [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
+          item,
+          index
+        ) {
+          if (index < loadImages) {
+            item.classList.remove(hiddenClass);
+          }
+          if (document.querySelectorAll('.' + hiddenClass).length === 0) {
+            loadMore.style.display = 'none';
+            noMore.classList.remove('hidden');
+          }
+        });
+      });
+    }
+  }
+
+  // Hide loader
+  if(document.getElementsByClassName(window.joomGrid.loaderclass)) {
+    const loaders = document.getElementsByClassName(window.joomGrid.loaderclass);
+
+    Array.from(loaders).forEach(loader => {
+      loader.classList.add('hidden');
+    });
+  }
+}; //end callback
+
+if(document.readyState === "complete" || (document.readyState !== "loading" && !document.documentElement.doScroll))
+{
+  callback();
+} else {
+  document.addEventListener("DOMContentLoaded", callback);
+}

--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -32,7 +32,7 @@ var callback = function() {
 
   // Initialize lightGallery
   if(window.joomGrid.lightbox) {
-    const lightbox = document.getElementById('lightgallery-' + window.joomGrid.id);
+    const lightbox = document.getElementById('lightgallery-' + window.joomGrid.itemid);
 
     window.joomGrid.lightboxes[window.joomGrid.itemid] = lightGallery(lightbox, {
       selector: '.lightgallery-item',

--- a/site/com_joomgallery/layouts/joomgallery/grids/images.php
+++ b/site/com_joomgallery/layouts/joomgallery/grids/images.php
@@ -38,7 +38,7 @@ extract($displayData);
 ?>
 
 <div class="jg-gallery <?php echo $layout; ?>" itemscope="" itemtype="https://schema.org/ImageGallery">
-  <div id="jg-loader"></div>
+  <div class="jg-loader"></div>
   <div id="lightgallery-<?php echo $id; ?>" class="jg-images <?php echo $layout; ?>-<?php echo $num_columns; ?> jg-category" data-masonry="{ pollDuration: 175 }">
     <?php foreach($items as $key => $item) : ?>
       

--- a/site/com_joomgallery/layouts/joomgallery/grids/images.php
+++ b/site/com_joomgallery/layouts/joomgallery/grids/images.php
@@ -1,0 +1,126 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+*****************************************************************************************/
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   int      $id              Layout id
+ * @var   string   $layout          Layout selection (columns, masonry, justified)
+ * @var   array    $items           List of objects that are displayed in a grid layout (id, catid, title, description, date, author)
+ * @var   int      $num_columns     Number of columns of this layout
+ * @var   string   $caption_align   Alignment class for the caption
+ * @var   string   $image_class     Class to be added to the image box
+ * @var   string   $image_type      Type of image to be displayed
+ * @var   string   $image_link      Type of link to be added to the image
+ * @var   bool     $image_title     True to display the image title
+ * @var   string   $title_link      Type of link to be added to the image title
+ * @var   bool     $image_desc      True to display the image description
+ * @var   bool     $image_date      True to display the image date
+ * @var   bool     $image_author    True to display the image author
+ * @var   bool     $image_tags      True to display the image tags
+ */
+?>
+
+<div class="jg-gallery <?php echo $layout; ?>" itemscope="" itemtype="https://schema.org/ImageGallery">
+  <div id="jg-loader"></div>
+  <div id="lightgallery-<?php echo $id; ?>" class="jg-images <?php echo $layout; ?>-<?php echo $num_columns; ?> jg-category" data-masonry="{ pollDuration: 175 }">
+    <?php foreach($items as $key => $item) : ?>
+      
+      <div class="jg-image">
+        <div class="jg-image-thumbnail<?php if($image_class && $layout != 'justified') : ?><?php echo ' boxed'; ?><?php endif; ?>">
+          <?php if($layout != 'justified') : ?>
+            <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
+          <?php endif; ?>
+
+          <?php if($image_link == 'lightgallery') : ?>
+            <a class="lightgallery-item" href="<?php echo JoomHelper::getImg($item, $image_type); ?>" data-sub-html="#jg-image-caption-<?php echo $item->id; ?>">
+              <img src="<?php echo JoomHelper::getImg($item, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $item->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if( $layout != 'justified') : ?> loading="lazy"<?php endif; ?>>
+              <?php if($image_title && $layout == 'justified') : ?>
+                <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
+                  <?php echo $this->escape($item->title); ?>
+                </div>
+              <?php endif; ?>
+              <?php if($image_title) : ?>
+                <div id="jg-image-caption-<?php echo $item->id; ?>" style="display: none">
+                  <div class="jg-image-caption <?php echo $caption_align; ?>">
+                    <?php echo $this->escape($item->title); ?>
+                  </div>
+                </div>
+              <?php endif; ?>
+            </a>
+          <?php elseif($image_link == 'defaultview') : ?>
+            <a href="<?php echo Route::_(JoomHelper::getViewRoute('image', (int) $item->id, (int) $item->catid)); ?>">
+              <img src="<?php echo JoomHelper::getImg($item, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $item->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if( $layout != 'justified') : ?> loading="lazy"<?php endif; ?>>
+              <?php if($image_title && $layout == 'justified') : ?>
+                <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
+                  <?php echo $this->escape($item->title); ?>
+                </div>
+              <?php endif; ?>
+            </a>
+          <?php else : ?>
+            <img src="<?php echo JoomHelper::getImg($item, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $item->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if( $layout != 'justified') : ?> loading="lazy"<?php endif; ?>>
+          <?php endif; ?>
+
+          <?php if($layout != 'justified') : ?>
+            </div>
+          <?php endif; ?>
+
+          <?php if($layout == 'justified') : ?>
+            <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
+              <?php echo $this->escape($item->title); ?>
+            </div>
+          <?php endif; ?>
+        </div>
+
+        <?php if($layout != 'justified') : ?>
+          <div class="jg-image-caption <?php echo $caption_align; ?>">
+            <?php if($image_title) : ?>
+              <?php if($title_link == 'lightgallery' && $image_link != 'lightgallery') : ?>
+                <a class="lightgallery-item" href="<?php echo JoomHelper::getImg($item, $image_type); ?>" data-sub-html="#jg-image-caption-<?php echo $item->id; ?>">
+                  <?php echo $this->escape($item->title); ?>
+                </a>
+              <?php else : ?>
+                <?php if($title_link == 'defaultview') : ?>
+                  <a href="<?php echo Route::_(JoomHelper::getViewRoute('image', (int) $item->id, (int) $item->catid)); ?>">
+                    <?php echo $this->escape($item->title); ?>
+                  </a>
+                <?php else : ?>
+                  <?php echo $this->escape($item->title); ?>
+                <?php endif; ?>
+              <?php endif; ?>
+            <?php endif; ?>
+
+            <?php if($image_desc) : ?>
+              <div><?php echo Text::_('JGLOBAL_DESCRIPTION') . ': ' . $item->description; ?></div>
+            <?php endif; ?>
+            <?php if($image_date) : ?>
+              <div><?php echo Text::_('COM_JOOMGALLERY_DATE') . ': ' . HTMLHelper::_('date', $item->date, Text::_('DATE_FORMAT_LC4')); ?></div>
+            <?php endif; ?>
+            <?php if($image_author) : ?>
+              <div><?php echo Text::_('JAUTHOR') . ': ' . $this->escape($item->author); ?></div>
+            <?php endif; ?>
+            <?php if($image_tags) : ?>
+              <div><?php echo Text::_('COM_JOOMGALLERY_TAGS') . ': '; ?></div>
+            <?php endif; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    <?php endforeach; ?>
+  </div>
+</div>

--- a/site/com_joomgallery/layouts/joomgallery/grids/subcategories.php
+++ b/site/com_joomgallery/layouts/joomgallery/grids/subcategories.php
@@ -30,7 +30,7 @@ $img_type = 'thumbnail';
 ?>
 
 <div class="jg-gallery" itemscope="" itemtype="https://schema.org/ImageGallery">
-  <div id="jg-loader"></div>
+  <div class="jg-loader"></div>
   <div class="jg-images <?php echo $layout; ?>-<?php echo $num_columns; ?> jg-subcategories" data-masonry="{ pollDuration: 175 }">
     <?php foreach($items as $key => $item) : ?>
       <?php

--- a/site/com_joomgallery/layouts/joomgallery/grids/subcategories.php
+++ b/site/com_joomgallery/layouts/joomgallery/grids/subcategories.php
@@ -1,0 +1,65 @@
+<?php
+/**
+******************************************************************************************
+**   @version    4.0.0-dev                                                                  **
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2023  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+*****************************************************************************************/
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $layout          Layout selection (columns, masonry, justified)
+ * @var   array    $items           List of objects that are displayed in a grid layout (properties: id, title, thumbnail)
+ * @var   int      $num_columns     Number of columns of this layout
+ * @var   string   $image_class     Class to be added to the image box
+ * @var   string   $caption_align   Alignment class for the caption
+ * @var   bool     $random_image    True, if a random inage should be loaded (only for categories)
+ */
+
+$img_type = 'thumbnail';
+?>
+
+<div class="jg-gallery" itemscope="" itemtype="https://schema.org/ImageGallery">
+  <div id="jg-loader"></div>
+  <div class="jg-images <?php echo $layout; ?>-<?php echo $num_columns; ?> jg-subcategories" data-masonry="{ pollDuration: 175 }">
+    <?php foreach($items as $key => $item) : ?>
+      <?php
+        if($item->thumbnail == 0 && $random_image)
+        {
+          $item->thumbnail = $item->id;
+          $img_type = 'rnd_cat:thumbnail';
+        }
+      ?>
+
+      <div class="jg-image">
+        <div class="jg-image-thumbnail<?php if($image_class && $layout != 'justified') : ?><?php echo ' boxed'; ?><?php endif; ?>">
+          <a href="<?php echo Route::_(JoomHelper::getViewRoute('category', (int) $item->id)); ?>">
+            <img src="<?php echo JoomHelper::getImg($item->thumbnail, $img_type); ?>" class="jg-image-thumb" alt="<?php echo $this->escape($item->title); ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if( $layout != 'justified') : ?> loading="lazy"<?php endif; ?>>
+            <?php if($layout == 'justified') : ?>
+              <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
+                <?php echo $this->escape($item->title); ?>
+              </div>
+            <?php endif; ?>
+          </a>
+        </div>
+        <?php if($layout != 'justified') : ?>
+          <div class="jg-image-caption <?php echo $caption_align; ?>">
+            <a class="jg-link" href="<?php echo Route::_(JoomHelper::getViewRoute('category', (int) $item->id)); ?>">
+              <?php echo $this->escape($item->title); ?>
+            </a>
+          </div>
+        <?php endif; ?>
+      </div>
+    <?php endforeach; ?>
+  </div>
+</div>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -38,7 +38,7 @@ $show_title       = $this->params['configs']->get('jg_category_view_images_show_
 $numb_images      = $this->params['configs']->get('jg_category_view_numb_images', 12, 'INT');
 $use_pagination   = $this->params['configs']->get('jg_category_view_pagination', 0, 'INT');
 $reloaded_images  = $this->params['configs']->get('jg_category_view_number_of_reloaded_images', 3, 'INT');
-$image_link       = $this->params['configs']->get('jg_category_view_image_link', 'detailview', 'STRING');
+$image_link       = $this->params['configs']->get('jg_category_view_image_link', 'defaultview', 'STRING');
 $title_link       = $this->params['configs']->get('jg_category_view_title_link', 'defaultview', 'STRING');
 $lightbox_image   = $this->params['configs']->get('jg_category_view_lightbox_image', 'detail', 'STRING');
 $show_description = $this->params['configs']->get('jg_category_view_show_description', 0, 'INT');
@@ -53,6 +53,7 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
 
 ?>
 
+<?php //Password protected category form ?>
 <?php if($this->item->pw_protected): ?>
   <form action="<?php echo Route::_('index.php?task=category.unlock&catid='.$this->item->id);?>" method="post" class="form-inline" autocomplete="off">
     <h3><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_PASSWORD_PROTECTED'); ?></h3>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -19,7 +19,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 
-// subcategory params
+// Subcategory params
 $subcategory_class          = $this->params['configs']->get('jg_category_view_subcategory_class', 'masonry', 'STRING');
 $subcategory_num_columns    = $this->params['configs']->get('jg_category_view_subcategory_num_columns', 3, 'INT');
 $subcategory_image_class    = $this->params['configs']->get('jg_category_view_subcategory_image_class', 0, 'INT');
@@ -27,7 +27,7 @@ $numb_subcategories         = $this->params['configs']->get('jg_category_view_nu
 $subcategories_pagination   = $this->params['configs']->get('jg_category_view_subcategories_pagination', 0, 'INT');
 $subcategories_random_image = $this->params['configs']->get('jg_category_view_subcategories_random_image', 1, 'INT');
 
-// image params
+// Image params
 $category_class   = $this->params['configs']->get('jg_category_view_class', 'masonry', 'STRING');
 $num_columns      = $this->params['configs']->get('jg_category_view_num_columns', 6, 'INT');
 $caption_align    = $this->params['configs']->get('jg_category_view_caption_align', 'right', 'STRING');
@@ -53,7 +53,7 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
 
 ?>
 
-<?php //Password protected category form ?>
+<?php // Password protected category form ?>
 <?php if($this->item->pw_protected): ?>
   <form action="<?php echo Route::_('index.php?task=category.unlock&catid='.$this->item->id);?>" method="post" class="form-inline" autocomplete="off">
     <h3><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_PASSWORD_PROTECTED'); ?></h3>
@@ -62,33 +62,37 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
     <button type="submit" class="btn btn-primary" id="jg_unlock_button"><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_BUTTON_UNLOCK'); ?></button>
     <?php echo HTMLHelper::_('form.token'); ?>
   </form>
+  <?php return; ?>
 <?php endif; ?>
 
-<?php
-if ($subcategory_class == 'masonry' || $category_class == 'masonry') {
+<?php // Import CSS & JS
+if($subcategory_class == 'masonry' || $category_class == 'masonry')
+{
   $wa->useScript('com_joomgallery.masonry');
 }
 
-if ($category_class == 'justified') {
+if($category_class == 'justified')
+{
   $wa->useScript('com_joomgallery.justified');
   $wa->addInlineStyle('.jg-images[class*=" justified-"] .jg-image-caption-hover { right: ' . $justified_gap . 'px; }');
 }
 
 $lightbox = false;
-if($image_link == 'lightgallery' || $title_link == 'lightgallery') {
+if($image_link == 'lightgallery' || $title_link == 'lightgallery')
+{
   $lightbox = true;
-}
 
-if($lightbox) {
   $wa->useScript('com_joomgallery.lightgallery');
   $wa->useScript('com_joomgallery.lg-thumbnail');
   $wa->useStyle('com_joomgallery.lightgallery-bundle');
 }
 
-if (!empty($use_pagination)) {
+if(!empty($use_pagination))
+{
   // $wa->useScript('com_joomgallery.infinite-scroll');
 }
 
+// Permission checks
 $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.category', $this->item->id);
 $canAdd     = $this->getAcl()->checkACL('add', 'com_joomgallery.category', 0, $this->item->id, true);
 if($this->item->id > 1)
@@ -102,15 +106,16 @@ else
 $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.category', $this->item->id);
 $canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $this->item->id) || $this->item->checked_out == Factory::getUser()->id;
 $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id, $this->item->parent_id, $this->item->language, $this->getLayout()));
-
 ?>
 
+<?php // Category title ?>
 <?php if($this->item->parent_id > 0) : ?>
   <h2><?php echo Text::_('JCATEGORY').': '.$this->escape($this->item->title); ?></h2>
 <?php else : ?>
   <h2><?php echo Text::_('COM_JOOMGALLERY') ?></h2>
 <?php endif; ?>
 
+<?php // Back to parent category ?>
 <?php if($this->item->parent_id > 0) : ?>
   <a class="jg-link btn btn-outline-primary" href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $this->item->parent_id); ?>">
     <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('Back to: Parent Category'); ?></span>
@@ -120,6 +125,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 
 <br>
 
+<?php // Edit buttons ?>
 <?php if($canEdit || $canAdd || $canDelete): ?>
   <div class="mb-3">
     <?php if($canEdit): ?>
@@ -156,8 +162,10 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   </div>
 <?php endif; ?>
 
+<?php // Category text ?>
 <p><?php echo $this->item->description; ?></p>
 
+<?php // Hint for no items ?>
 <?php if(count($this->item->children->items) == 0 && count($this->item->images->items) == 0) : ?>
   <p><?php echo Text::_('No elements in this category...') ?></p>
 <?php endif; ?>
@@ -169,48 +177,20 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <?php else : ?>
     <h3><?php echo Text::_('COM_JOOMGALLERY_CATEGORIES') ?></h3>
   <?php endif; ?>
-  <div class="jg-gallery" itemscope="" itemtype="https://schema.org/ImageGallery">
-    <?php if(!($this->item->parent_id > 0)) : ?>
-      <div id="jg-loader"></div>
-    <?php endif; ?>
-    <div class="jg-images <?php echo $subcategory_class; ?>-<?php echo $subcategory_num_columns; ?> jg-subcategories" data-masonry="{ pollDuration: 175 }">
-      <?php foreach($this->item->children->items as $key => $subcat) : ?>
-        <div class="jg-image">
-          <div class="jg-image-thumbnail<?php if($subcategory_image_class && $subcategory_class != 'justified') : ?><?php echo ' boxed'; ?><?php endif; ?>">
-            <a href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $subcat->id); ?>">
-              <?php
-                $thumb_type = 'thumbnail';
-                if($subcat->thumbnail == 0 && $subcategories_random_image)
-                {
-                  $subcat->thumbnail = $subcat->id;
-                  $thumb_type = 'rnd_cat:thumbnail';
-                }
-              ?>
-              <img src="<?php echo JoomHelper::getImg($subcat->thumbnail, $thumb_type); ?>" class="jg-image-thumb" alt="<?php echo $this->escape($subcat->title); ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if ( $subcategory_class != 'justified') : ?> loading="lazy"<?php endif; ?>>
 
-              <?php if($subcategory_class == 'justified') : ?>
-              <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
-              <?php echo $this->escape($subcat->title); ?>
-              </div>
-              <?php endif; ?>
-            </a>
-          </div>
-          <?php if($subcategory_class != 'justified') : ?>
-          <div class="jg-image-caption <?php echo $caption_align; ?>">
-            <a class="jg-link" href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $subcat->id); ?>">
-              <?php echo $this->escape($subcat->title); ?>
-            </a>
-          </div>
-          <?php endif; ?>
-        </div>
-      <?php endforeach; ?>
-    </div>
-  </div>
+  <?php // Display data array for layout
+    $subcatData = [ 'layout' => $subcategory_class, 'items' => $this->item->children->items, 'num_columns' => (int) $subcategory_num_columns,
+                    'image_class' => $subcategory_image_class, 'random_image' => (bool) $subcategories_random_image
+                  ];
+  ?>
+
+  <?php // Subcategories grid ?>
+  <?php echo LayoutHelper::render('joomgallery.grids.subcategories', $subcatData); ?>
 <?php endif; ?>
 
 <?php // Category ?>
 <?php if(count($this->item->images->items) > 0) : ?>
-  <h3>Images</h3>
+  <h3><?php echo Text::_('COM_JOOMGALLERY_IMAGES') ?></h3>
   <?php if(!empty($this->item->images->filterForm) && $use_pagination == '0') : ?>
     <?php // Show image filters ?>
     <form action="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.$this->item->id.'&Itemid='.$this->menu->id); ?>" method="post" name="adminForm" id="adminForm">
@@ -229,118 +209,35 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
       <?php echo HTMLHelper::_('form.token'); ?>
     </form>
   <?php endif; ?>
-  <div class="jg-gallery<?php echo ' ' . $category_class; ?>" itemscope="" itemtype="https://schema.org/ImageGallery">
-    <div id="jg-loader"></div>
-    <div id="lightgallery-<?php echo $this->item->id; ?>" class="jg-images <?php echo $category_class; ?>-<?php echo $num_columns; ?> jg-category" data-masonry="{ pollDuration: 175 }">
-      <?php foreach($this->item->images->items as $key => $image) : ?>
-        <div class="jg-image">
-          <div class="jg-image-thumbnail<?php if($image_class && $category_class != 'justified') : ?><?php echo ' boxed'; ?><?php endif; ?>">
-            <?php if($category_class != 'justified') : ?>
-              <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
-            <?php endif; ?>
 
-            <?php if($image_link == 'lightgallery') : ?>
-              <a class="lightgallery-item" href="<?php echo JoomHelper::getImg($image, $lightbox_image); ?>" data-sub-html="#jg-image-caption-<?php echo $image->id; ?>">
-                <img src="<?php echo JoomHelper::getImg($image, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $image->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if ( $category_class != 'justified') : ?> loading="lazy"<?php endif; ?>>
-                <?php if($show_title && $category_class == 'justified') : ?>
-                  <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
-                    <?php echo $this->escape($image->title); ?>
-                  </div>
-                <?php endif; ?>
-                <?php if($show_title) : ?>
-                  <div id="jg-image-caption-<?php echo $image->id; ?>" style="display: none">
-                    <div class="jg-image-caption <?php echo $caption_align; ?>">
-                      <?php echo $this->escape($image->title); ?>
-                    </div>
-                  </div>
-                <?php endif; ?>
-              </a>
-            <?php endif; ?>
+  <?php // Display data array for layout
+    $imgsData = [ 'id' => (int) $this->item->id, 'layout' => $category_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,
+                  'caption_align' => $caption_align, 'image_class' => $image_class, 'image_type' => $lightbox_image, 'image_link' => $image_link,
+                  'image_title' => (bool) $show_title, 'title_link' => $title_link, 'image_desc' => (bool) $show_description, 'image_date' => (bool) $show_imgdate,
+                  'image_author' => (bool) $show_imgauthor, 'image_tags' => (bool) $show_tags
+                ];
+  ?>
 
-            <?php if($image_link == 'defaultview') : ?>
-              <a href="<?php echo Route::_(JoomHelper::getViewRoute('image', (int) $image->id, (int) $image->catid)); ?>">
-                <img src="<?php echo JoomHelper::getImg($image, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $image->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if ( $category_class != 'justified') : ?> loading="lazy"<?php endif; ?>>
-                <?php if($show_title && $category_class == 'justified') : ?>
-                  <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
-                    <?php echo $this->escape($image->title); ?>
-                  </div>
-                <?php endif; ?>
-              </a>
-            <?php endif; ?>
+  <?php // Images grid ?>
+  <?php echo LayoutHelper::render('joomgallery.grids.images', $imgsData); ?>
 
-            <?php if($image_link == 'none') : ?>
-              <img src="<?php echo JoomHelper::getImg($image, 'thumbnail'); ?>" class="jg-image-thumb" alt="<?php echo $image->title; ?>" itemprop="image" itemscope="" itemtype="https://schema.org/image"<?php if ( $category_class != 'justified') : ?> loading="lazy"<?php endif; ?>>
-            <?php endif; ?>
-
-            <?php if($category_class != 'justified') : ?>
-              </div>
-            <?php endif; ?>
-
-            <?php if($category_class == 'justified') : ?>
-              <div class="jg-image-caption-hover <?php echo $caption_align; ?>">
-                <?php echo $this->escape($image->title); ?>
-              </div>
-            <?php endif; ?>
-
-          </div>
-
-          <?php if($category_class != 'justified') : ?>
-          <div class="jg-image-caption <?php echo $caption_align; ?>">
-            <?php if ($show_title) : ?>
-              <?php if($title_link == 'lightgallery' && $image_link != 'lightgallery') : ?>
-                <a class="lightgallery-item" href="<?php echo JoomHelper::getImg($image, $lightbox_image); ?>" data-sub-html="#jg-image-caption-<?php echo $image->id; ?>">
-                  <?php echo $this->escape($image->title); ?>
-                </a>
-              <?php else : ?>
-                <?php if($title_link == 'defaultview') : ?>
-                  <a href="<?php echo Route::_(JoomHelper::getViewRoute('image', (int) $image->id, (int) $image->catid)); ?>">
-                    <?php echo $this->escape($image->title); ?>
-                  </a>
-                <?php else : ?>
-                  <?php echo $this->escape($image->title); ?>
-                <?php endif; ?>
-              <?php endif; ?>
-            <?php endif; ?>
-
-            <?php if($show_description) : ?>
-              <div><?php echo Text::_('JGLOBAL_DESCRIPTION') . ': ' . $image->description; ?></div>
-            <?php endif; ?>
-            <?php if($show_imgdate) : ?>
-              <div><?php echo Text::_('COM_JOOMGALLERY_DATE') . ': ' . HTMLHelper::_('date', $image->date, Text::_('DATE_FORMAT_LC4')); ?></div>
-            <?php endif; ?>
-            <?php if($show_imgauthor) : ?>
-              <div><?php echo Text::_('JAUTHOR') . ': ' . $this->escape($image->author); ?></div>
-            <?php endif; ?>
-            <?php if($show_tags) : ?>
-              <div><?php echo Text::_('COM_JOOMGALLERY_TAGS') . ': '; ?></div>
-            <?php endif; ?>
-          </div>
-          <?php endif; ?>
-        </div>
-      <?php endforeach; ?>
-    </div>
+  <?php // Pagination ?>
+  <?php if($use_pagination == 1) : ?>
+  <div class="load-more-container">
+    <div class="infinite-scroll"></div>
+    <div id="noMore" class="btn btn-outline-primary no-more-images hidden"><?php echo Text::_('COM_JOOMGALLERY_NO_MORE_IMAGES') ?></div>
   </div>
-
-  <?php if ( $use_pagination == '0' ) : ?>
-    <?php echo $this->item->images->pagination->getListFooter(); ?>
-  <?php endif; ?>
-
-  <?php if ( $use_pagination == '1' ) : ?>
-    <div class="load-more-container">
-      <div class="infinite-scroll"></div>
-      <div id="noMore" class="btn btn-outline-primary no-more-images hidden"><?php echo Text::_('COM_JOOMGALLERY_NO_MORE_IMAGES') ?></div>
-    </div>
-  <?php endif; ?>
-
-  <?php if ( $use_pagination == '2') : ?>
+  <?php elseif($use_pagination == 2) : ?>
     <div class="load-more-container">
       <div id="loadMore" class="btn btn-outline-primary load-more"><span><?php echo Text::_('COM_JOOMGALLERY_LOAD_MORE') ?></span><i class="jg-icon-expand-more"></i></div>
       <div id="noMore" class="btn btn-outline-primary no-more-images hidden"><?php echo Text::_('COM_JOOMGALLERY_NO_MORE_IMAGES') ?></div>
     </div>
+  <?php else : ?>
+    <?php echo $this->item->images->pagination->getListFooter(); ?>
   <?php endif; ?>
-
 <?php endif; ?>
 
+<?php // Add image button ?>
 <?php /*if($canAddImg) : ?>
   <div class="mb-2">
     <a href="<?php echo Route::_('index.php?option=com_joomgallery&task=image.add&id=0&catid='.$this->item->id.'&return='.$returnURL, false, 0); ?>" class="btn btn-success btn-small">
@@ -350,114 +247,150 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   </div>
 <?php endif; */?>
 
-<?php if ( $lightbox ) : ?>
-<script>
-const jgallery<?php echo $this->item->id; ?> = lightGallery(document.getElementById('lightgallery-<?php echo $this->item->id; ?>'), {
-  selector: '.lightgallery-item',
-  // allowMediaOverlap: true,
-  thumbHeight: '50px',
-  thumbMargin: 5,
-  thumbWidth: 75,
-  thumbnail: true,
-  toggleThumb: true,
-  speed: 500,
-  plugins: [lgThumbnail],
-  preload: 1,
-  loop: false,
-  counter: true,
-  download: false,
-  mobileSettings: {
-    controls: false,
-    showCloseIcon: true,
-    download: false,
-  },
-  licenseKey: '1111-1111-111-1111',
-});
-if(document.getElementById('lightgallery-<?php echo $this->item->id; ?>')) {
-  jgallery<?php echo $this->item->id; ?>.outer.on('click', (e) => {
-    const $item = jgallery<?php echo $this->item->id; ?>.outer.find('.lg-current .lg-image');
-    if (
-      e.target.classList.contains('lg-image') ||
-      $item.get().contains(e.target)
-    ) {
-      jgallery<?php echo $this->item->id; ?>.goToNextSlide();
+<?php if($lightbox) : ?>
+  <script>
+    const jgallery<?php echo $this->item->id; ?> = lightGallery(document.getElementById('lightgallery-<?php echo $this->item->id; ?>'), {
+      selector: '.lightgallery-item',
+      // allowMediaOverlap: true,
+      thumbHeight: '50px',
+      thumbMargin: 5,
+      thumbWidth: 75,
+      thumbnail: true,
+      toggleThumb: true,
+      speed: 500,
+      plugins: [lgThumbnail],
+      preload: 1,
+      loop: false,
+      counter: true,
+      download: false,
+      mobileSettings: {
+        controls: false,
+        showCloseIcon: true,
+        download: false,
+      },
+      licenseKey: '1111-1111-111-1111',
+    });
+    if(document.getElementById('lightgallery-<?php echo $this->item->id; ?>')) {
+      jgallery<?php echo $this->item->id; ?>.outer.on('click', (e) => {
+        const $item = jgallery<?php echo $this->item->id; ?>.outer.find('.lg-current .lg-image');
+        if (
+          e.target.classList.contains('lg-image') ||
+          $item.get().contains(e.target)
+        ) {
+          jgallery<?php echo $this->item->id; ?>.goToNextSlide();
+        }
+      });
     }
+  </script>
+<?php endif; ?>
+
+<?php if($category_class == 'justified') : ?>
+  <script>
+    window.addEventListener('load', function () {
+      const container = document.querySelector('.jg-category');
+      const imgs = document.querySelectorAll('.jg-category img');
+      const options = {
+        idealHeight: <?php echo $justified_height; ?>,
+        maxRowImgs: 32,
+        rowGap: <?php echo $justified_gap; ?>,
+        columnGap: <?php echo $justified_gap; ?>,
+      };
+      const imgjust = new ImgJust(container, imgs, options);
+    });
+  </script>
+<?php else: ?>
+  <script>
+    let images = document.getElementsByClassName('jg-image-thumb');
+    for (let image of images) {
+      image.addEventListener('load', loadImg);
+    }
+    function loadImg () {
+      this.closest('.jg-image').classList.add('loaded');
+    }
+  </script>
+<?php endif; ?>
+
+<?php /*if(count($this->item->children->items) > 0 && $category_class == 'justified') : ?>
+  <?php // zerstört subcategory layout ?>
+  <script>
+  window.addEventListener('load', function () {
+    const container = document.querySelector('.jg-subcategories');
+    const imgs = document.querySelectorAll('.jg-subcategories img');
+    const options = {
+      idealHeight: <?php echo $justified_height; ?>,
+      maxRowImgs: 32,
+      rowGap: <?php echo $justified_gap; ?>,
+      columnGap: <?php echo $justified_gap; ?>,
+    };
+    const imgjust = new ImgJust(container, imgs, options);
   });
-}
-</script>
+  </script>
+<?php endif; */?>
+
+<?php if($use_pagination == '1') : ?>
+  <script>
+    const category = document.querySelector('.jg-category');
+    const items = Array.from(category.querySelectorAll('.jg-image'));
+
+    maxImages    = <?php echo $num_columns * 2; ?>;
+    loadImages   = <?php echo $num_columns * 3; ?>;
+    hiddenClass  = 'hidden-jg-image';
+    hiddenImages = Array.from(document.querySelectorAll('.hidden-jg-image'));
+
+    items.forEach(function (item, index) {
+      if (index > maxImages - 1) {
+        item.classList.add(hiddenClass);
+      }
+    });
+
+    const observerOptions = {
+      root: null,
+      rootMargin: '200px',
+      threshold: 0
+    };
+
+    function observerCallback(entries, observer) {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
+            item,
+            index
+          ) {
+            if (index < loadImages) {
+              item.classList.remove(hiddenClass);
+            }
+            if (document.querySelectorAll('.' + hiddenClass).length === 0) {
+              noMore.classList.remove('hidden');
+            }
+          });
+          // console.log('enter');
+        }
+      });
+    }
+    const fadeElms = document.querySelectorAll('.infinite-scroll');
+    const observer = new IntersectionObserver(observerCallback, observerOptions);
+    fadeElms.forEach(el => observer.observe(el));
+  </script>
 <?php endif; ?>
 
-<?php if ( $category_class != 'justified') : ?>
-<script>
-let images = document.getElementsByClassName('jg-image-thumb');
-for (let image of images) {
-  image.addEventListener('load', loadImg);
-}
-function loadImg () {
-  this.closest('.jg-image').classList.add('loaded');
-}
-</script>
-<?php endif; ?>
+<?php if($use_pagination == '2') : ?>
+  <script>
+    const category = document.querySelector('.jg-category');
+    const items    = Array.from(category.querySelectorAll('.jg-image'));
+    const loadMore = document.getElementById('loadMore');
 
-<?php if(count($this->item->children->items) > 0 && $category_class == 'justified') : ?>
-<?php /* zerstört subcategory layout
-<script>
-window.addEventListener('load', function () {
-  const container = document.querySelector('.jg-subcategories');
-  const imgs = document.querySelectorAll('.jg-subcategories img');
-  const options = {
-    idealHeight: <?php echo $justified_height; ?>,
-    maxRowImgs: 32,
-    rowGap: <?php echo $justified_gap; ?>,
-    columnGap: <?php echo $justified_gap; ?>,
-  };
-  const imgjust = new ImgJust(container, imgs, options);
-});
-</script>
-*/ ?>
-<?php endif; ?>
+    maxImages    = <?php echo $num_columns * 2; ?>;
+    loadImages   = <?php echo $reloaded_images; ?>;
+    hiddenClass  = 'hidden-jg-image';
+    hiddenImages = Array.from(document.querySelectorAll('.hidden-jg-image'));
 
-<?php if ( $category_class == 'justified') : ?>
-<script>
-window.addEventListener('load', function () {
-  const container = document.querySelector('.jg-category');
-  const imgs = document.querySelectorAll('.jg-category img');
-  const options = {
-    idealHeight: <?php echo $justified_height; ?>,
-    maxRowImgs: 32,
-    rowGap: <?php echo $justified_gap; ?>,
-    columnGap: <?php echo $justified_gap; ?>,
-  };
-  const imgjust = new ImgJust(container, imgs, options);
-});
-</script>
-<?php endif; ?>
+    items.forEach(function (item, index) {
+      if (index > maxImages - 1) {
+        item.classList.add(hiddenClass);
+      }
+    });
 
-<?php if ( $use_pagination == '1') : ?>
-<script>
-const category = document.querySelector('.jg-category');
-const items = Array.from(category.querySelectorAll('.jg-image'));
-
-maxImages    = <?php echo $num_columns * 2; ?>;
-loadImages   = <?php echo $num_columns * 3; ?>;
-hiddenClass  = 'hidden-jg-image';
-hiddenImages = Array.from(document.querySelectorAll('.hidden-jg-image'));
-
-items.forEach(function (item, index) {
-  if (index > maxImages - 1) {
-    item.classList.add(hiddenClass);
-  }
-});
-
-const observerOptions = {
-  root: null,
-  rootMargin: '200px',
-  threshold: 0
-};
-
-function observerCallback(entries, observer) {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
+    loadMore.addEventListener('click', function () {
       [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
         item,
         index
@@ -466,60 +399,20 @@ function observerCallback(entries, observer) {
           item.classList.remove(hiddenClass);
         }
         if (document.querySelectorAll('.' + hiddenClass).length === 0) {
+          loadMore.style.display = 'none';
           noMore.classList.remove('hidden');
         }
       });
-      // console.log('enter');
-    }
-  });
-}
-
-const fadeElms = document.querySelectorAll('.infinite-scroll');
-const observer = new IntersectionObserver(observerCallback, observerOptions);
-fadeElms.forEach(el => observer.observe(el));
-
-</script>
+    });
+  </script>
 <?php endif; ?>
 
-<?php if ( $use_pagination == '2') : ?>
+<?php // Hide loader when page is loaded ?>
 <script>
-const category = document.querySelector('.jg-category');
-const items    = Array.from(category.querySelectorAll('.jg-image'));
-const loadMore = document.getElementById('loadMore');
-
-maxImages    = <?php echo $num_columns * 2; ?>;
-loadImages   = <?php echo $reloaded_images; ?>;
-hiddenClass  = 'hidden-jg-image';
-hiddenImages = Array.from(document.querySelectorAll('.hidden-jg-image'));
-
-items.forEach(function (item, index) {
-  if (index > maxImages - 1) {
-    item.classList.add(hiddenClass);
-  }
-});
-
-loadMore.addEventListener('click', function () {
-  [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
-    item,
-    index
-  ) {
-    if (index < loadImages) {
-      item.classList.remove(hiddenClass);
+  window.onload = function() {
+    if(document.querySelector('#jg-loader')) { 
+      const el = document.querySelector('#jg-loader');
+      el.classList.add('hidden');
     }
-    if (document.querySelectorAll('.' + hiddenClass).length === 0) {
-      loadMore.style.display = 'none';
-      noMore.classList.remove('hidden');
-    }
-  });
-});
-</script>
-<?php endif; ?>
-
-<script>
-window.onload = function() {
-  if(document.querySelector('#jg-loader')) { 
-    const el = document.querySelector('#jg-loader');
-    el.classList.add('hidden');
-  }
-};
+  };
 </script>


### PR DESCRIPTION
This PR does not change any functionality, but cleans up the code of the category view template and make it reusable.

When applying this PR there are the following files newly in the JoomGallery filesystem:
- **_media/com_joomgallery/js/joomgrid.js_**
  containing the majority of the before inline javascript code
- **_components/com_joomgallery/layouts/joomgallery/grids/subcategories.php_**
  containing the html template for a grid of subcategory-images
- **_components/com_joomgallery/layouts/joomgallery/grids/images.php_**
  containing the html template for a grid of images

This paves the way for easy creation of grid views at various locations. E.g. content plugin, category module, ...

### How to test this PR
The category view should act the same way as before and no errors should appear