### PR TITLE
Fix issue with onMigrationBeforeSave event

### DIFF
--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -17,6 +17,7 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Form\Form;
+use \Joomla\CMS\Event\Model;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Registry\Registry;
 use \Joomla\CMS\Filesystem\Path;
@@ -1286,9 +1287,24 @@ class MigrationModel extends JoomAdminModel
     }
 
     // Trigger the onMigrationBeforeSave event
-    $event = new \Joomla\Event\Event('onMigrationBeforeSave', ['com_joomgallery.'.$recordType, $table]);
-    $this->getDispatcher()->dispatch($event->getName(), $event);
-    $results = $event->getArgument('result', []);
+    if(\version_compare(JVERSION, '5.0.0', '<'))
+    {
+      // Joomla 4
+      $event = new \Joomla\Event\Event('onMigrationBeforeSave', ['com_joomgallery.'.$recordType, $table]);
+      $this->getDispatcher()->dispatch($event->getName(), $event);
+      $results = $event->getArgument('result', []);
+    }
+    else
+    {
+      // Joomla 5
+      $options = ['context' => 'com_joomgallery.'.$recordType,
+                  'subject' => $table,
+                  'isNew'   => $isNew,
+                  'data'    => $data,
+                 ];
+      $event = new Model\BeforeSaveEvent('onMigrationBeforeSave', $options);
+      $results = $this->getDispatcher()->dispatch($event->getName(), $event)->getArgument('result', []);
+    }
 
     // Store the data.
     if(\in_array(false, $results, true) || !$table->store())


### PR DESCRIPTION
This PR fixes the issue reported in #298 

The way how the onMigrationBeforeSave event is triggered has to be changed now after PR #292 is merged. In Joomla 5+, we have to use the dedicated events like `Joomla\CMS\Event\Model\BeforeSaveEvent` containing special methods like `getItem()`. The `Joomla\Event\Event` method can not be used anymore in Joomla 5+ while it still has to be used in Joomla 4.x.

In order to support both Joomla versions, we need a switch and both ways of triggering the event. Thanks @joomla/joomla-cms for this additional work ;-)

--> Here you can see now the double work to be done by developers if you want to have backward compatibility!

### How to test this PR
The migrations should be working again with this PR applied.