### PR TITLE
Allow external usage of JG Fields

### DIFF
--- a/administrator/com_joomgallery/src/Field/JgcategoryField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategoryField.php
@@ -107,8 +107,11 @@ class JgcategoryField extends FormField
 			throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		// Make sure the component is correctly set
+		$renderer = $this->getRenderer($this->layout);
+		$renderer->setComponent('com_joomgallery');
 
+		return $renderer->render($this->getLayoutData());
 	}
 
 	/**

--- a/administrator/com_joomgallery/src/Field/JgimageField.php
+++ b/administrator/com_joomgallery/src/Field/JgimageField.php
@@ -106,8 +106,11 @@ class JgimageField extends FormField
 			throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		// Make sure the component is correctly set
+		$renderer = $this->getRenderer($this->layout);
+		$renderer->setComponent('com_joomgallery');
 
+		return $renderer->render($this->getLayoutData());
 	}
 
 	/**

--- a/administrator/com_joomgallery/src/Field/JglistField.php
+++ b/administrator/com_joomgallery/src/Field/JglistField.php
@@ -65,7 +65,11 @@ class JglistField extends ListField
       $data['globvalue'] = $this->getGlobalValue('...');
     }
 
-    return $this->getRenderer($this->layout)->render($data);
+    // Make sure the component is correctly set
+    $renderer = $this->getRenderer($this->layout);
+    $renderer->setComponent('com_joomgallery');
+
+    return $renderer->render($data);
   }
 
   /**

--- a/administrator/com_joomgallery/src/Field/JgtagField.php
+++ b/administrator/com_joomgallery/src/Field/JgtagField.php
@@ -116,7 +116,11 @@ class JgtagField extends ListField
         //$data['minTermLength'] = (int) $this->comParams->get('min_term_length', 3);
         $data['minTermLength'] = 3;
 
-        return $this->getRenderer($this->layout)->render($data);
+        // Make sure the component is correctly set
+        $renderer = $this->getRenderer($this->layout);
+        $renderer->setComponent('com_joomgallery');
+
+        return $renderer->render($data);
     }
 
     /**

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -345,6 +345,25 @@ class JoomHelper
     return $return;
   }
 
+  /**
+   * Checks the ACL permission for an asset on which to perform an action.
+   *
+   * @param   string   $action     The name of the action to check for permission.
+   * @param   string   $asset      The name of the asset on which to perform the action.
+   * @param   integer  $pk         The primary key of the item.
+   *
+   * @return  bool     True if the permission is granted, false otherwise
+   *
+   * @since   4.0.0
+   */
+  public static function checkACL($action, $asset='', $pk=0)
+  {
+    // Create access service
+    $acl = self::getService('Access');
+
+    return $acl->checkACL($action, $asset, $pk);
+  }
+
 	/**
 	 * Gets a list of the actions that can be performed.
    * 

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -463,9 +463,9 @@ class JoomHelper
 
     if(!\is_object($img))
     {
-      if(\is_numeric($img))
+      if(\is_numeric($img) || $img == 'null')
       {
-        if($img == 0)
+        if($img == 0 || $img == 'null')
         {
           // ID = 0 given
           return self::getImgZero($type, $url, $root);          
@@ -713,7 +713,7 @@ class JoomHelper
     // Create the link
     $link = 'index.php?option=' . _JOOM_OPTION . '&view=' . $view;
 
-    if($id > 0)
+    if($id > 0 || ($view == 'image' && $id >= 0))
     {
       $link .= '&id=' . $id;
     }

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -37,8 +37,9 @@ class RawView extends JoomGalleryView
 	public function display($tpl = null)
 	{
     // Get request variables
-    $type = $this->app->input->get('type', 'thumbnail', 'word');
-    $id   = $this->app->input->get('id', 0, 'int');
+    $type  = $this->app->input->get('type', 'thumbnail', 'word');
+    $id    = $this->app->input->get('id', 0);
+    if($id !== 'null') {$id = $this->app->input->get('id', 0, 'int');}
 
     // Check access
     if(!$this->access($id))
@@ -51,9 +52,10 @@ class RawView extends JoomGalleryView
 
     // Create filesystem service
     $adapter = '';
-    if($id === 0)
+    if($id === 0 || $id === 'null')
     {
       // Force local-images adapter to load the no-image file
+      $id      = 0;
       $adapter = 'local-images';
     }
     $this->component->createFilesystem($adapter);

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -44,7 +44,7 @@ img.jg-controlpanel-logo {
   background-color: var(--template-bg-dark-50) !important;
   border-color: var(--template-bg-dark-50) !important;
 }
-.modal .btn-primary {
+.admin .modal .btn-primary {
   background-color: var(--btn-primary-bg) !important;
 }
 .modal .btn-secondary {

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -71,9 +71,7 @@ img.jg-controlpanel-logo {
 }
 .modal .modal-body {
   margin: 1rem 2rem;
-}
-.modal .modal-body {
-  margin: 1rem 2rem;
+  overflow-y: scroll;
 }
 td .modal .form-control {
   width: 100%;

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -44,6 +44,12 @@ img.jg-controlpanel-logo {
   background-color: var(--template-bg-dark-50) !important;
   border-color: var(--template-bg-dark-50) !important;
 }
+.modal .btn-primary {
+  background-color: var(--btn-primary-bg) !important;
+}
+.modal .btn-secondary {
+  color: var(--white) !important;
+}
 .head-row .control-group .control-label {
   width: 150px;
 }

--- a/media/com_joomgallery/js/field-category.js
+++ b/media/com_joomgallery/js/field-category.js
@@ -147,8 +147,7 @@
 
 
     modalClose() {
-      Joomla.Modal.getCurrent().close();
-      this.modalBody.innerHTML = '';
+      this.modal.close();
     } // Remove the iframe
 
 

--- a/media/com_joomgallery/js/field-image.js
+++ b/media/com_joomgallery/js/field-image.js
@@ -156,8 +156,7 @@
 
 
     modalClose() {
-      Joomla.Modal.getCurrent().close();
-      this.modalBody.innerHTML = '';
+      this.modal.close();
     } // Remove the iframe
 
 

--- a/site/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -11,5 +11,5 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/configlist.php';
+$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/jgcategory.php';
 require $path;

--- a/site/com_joomgallery/layouts/joomla/form/field/jgimage.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgimage.php
@@ -11,5 +11,5 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/configlist.php';
+$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/jgimage.php';
 require $path;

--- a/site/com_joomgallery/layouts/joomla/form/field/jgtag.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgtag.php
@@ -11,5 +11,5 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/configlist.php';
+$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/jgtag.php';
 require $path;

--- a/site/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
@@ -11,5 +11,5 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$path = JPATH_ADMINISTRATOR . '/components/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php';
-require($path);
+$path = _JOOM_PATH_ADMIN . '/layouts/joomla/form/field/radio/configbtns.php';
+require $path;

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -301,6 +301,12 @@ class DefaultRouter extends RouterView
    */
   public function getImageId($segment, $query)
   {
+    if($segment == '0-' || $segment == 'noimage' || $segment == '0-noimage')
+    {
+      // Special case: No image with id=0
+      return 'null';
+    }
+
     $img_id = 0;
     if(\is_numeric(\explode('-', $segment, 2)[0]))
     {

--- a/site/com_joomgallery/src/View/Image/RawView.php
+++ b/site/com_joomgallery/src/View/Image/RawView.php
@@ -178,6 +178,8 @@ class RawView extends AdminRawView
 	 */
   protected function access($id)
   {
+    if($id === 'null') return true;
+
     $loaded = true;
     $access = true;
 


### PR DESCRIPTION
This PR adds the possibility to use the JoomGallery specific fields in forms outside of the JoomGallery component.

It affects the fields of type:

- jgcategory
- jgimage
- jglist
- jgtag

### How to test this PR
- Visit the edit forms of image, category, tag in the backend. The form fields still have to be correctly shown.