### PR TITLE
Imporve error logging during migration

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -885,6 +885,10 @@ COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_JOOMLA_PATH="The given Joomla! path does
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DB_CREDENTIALS="The given database credentials are not correct. Error from the database driver:<br />%s"
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DB_PREFIX="No tables with the provided database tables prefix found."
 COM_JOOMGALLERY_SERVICE_MIGRATION_PREREQUIREMENT_ERROR="Error: previous requirement not met. Requirement that has errors: %s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT="Check whether the file is available in the source."
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH="Path where the file is looked for: %s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_END_MIGRATE="Migration of the record ended. Type: %s; Source ID: %s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_CONCELLED="Migration of the record cancelled! ID: %s"
 
 ;Menu
 COM_JOOMGALLERY_MENU_CATEGORY_VIEW_OPTIONS="Category View"

--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -868,7 +868,6 @@ class MigrationModel extends JoomAdminModel
         {
           $success = false;
           $error_msg = Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_CONVERT_DATA');
-          $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_CONVERT_DATA'), 'error', 'migration');
         }
         else
         {
@@ -880,7 +879,6 @@ class MigrationModel extends JoomAdminModel
           {
             $success = false;
             $error_msg = Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_INSERT_RECORD');
-            $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_INSERT_RECORD'), 'error', 'migration');
           }
           else
           {
@@ -917,7 +915,7 @@ class MigrationModel extends JoomAdminModel
               $success = false;
               $error_msg = Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_'.$error_msg_end);
               $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_' . $error_msg_end), 'error', 'migration');
-              $this->component->addLog('Migration of the record cancelled! ID: ' . $new_pk, 'error', 'migration');
+              $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_CONCELLED', $new_pk), 'error', 'migration');
             }
           }
         }
@@ -926,7 +924,6 @@ class MigrationModel extends JoomAdminModel
       {
         $success = false;
         $error_msg = Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_FETCH_DATA');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_FAILED_FETCH_DATA'), 'error', 'migration');
       }
     }
 
@@ -1003,7 +1000,7 @@ class MigrationModel extends JoomAdminModel
     // Add log entry
     if($extented_log)
     {
-      $this->component->addLog('End migrate; type: ' . $type . '; source id: ' . $pk, 'info', 'migration');
+      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_END_MIGRATE', $type, $pk), 'info', 'migration');
       $this->component->addLog('---------------------------------------------', 'info', 'migration');
     }
 

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -108,18 +108,19 @@ class FileManager implements FileManagerInterface
    * @param   bool                 $processing    True to create imagetypes by processing source (defualt: True)
    * @param   bool                 $local_source  True if the source is a file located in a local folder (default: True)
    * @param   array                $skip          List of imagetypes to skip creation (default: [])
+   * @param   string               $logfile       Name of the logfile to use
    * 
    * @return  bool                 True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function createImages($source, $filename, $cat=2, $processing=True, $local_source=True, $skip=[]): bool
+  public function createImages($source, $filename, $cat=2, $processing=True, $local_source=True, $skip=[], $logfile = 'jerror'): bool
   {
     if(!$filename)
     {
       // Debug info
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CLEAN_FILENAME', \basename($source)));
-      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CLEAN_FILENAME', \basename($source)), 'error', 'jerror');
+      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CLEAN_FILENAME', \basename($source)), 'error', $logfile);
 
       return false;
     }
@@ -216,7 +217,7 @@ class FileManager implements FileManagerInterface
 
           // Debug info
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
           $error = true;
 
           continue;
@@ -230,7 +231,7 @@ class FileManager implements FileManagerInterface
 
           // Debug info
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
 
           continue;
         }
@@ -246,7 +247,7 @@ class FileManager implements FileManagerInterface
 
             // Debug info
             $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
             $error = true;
 
             continue;
@@ -269,7 +270,7 @@ class FileManager implements FileManagerInterface
 
             // Debug info
             $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
             $error = true;
 
             continue;
@@ -292,7 +293,7 @@ class FileManager implements FileManagerInterface
 
             // Debug info
             $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
             $error = true;
 
             continue;
@@ -325,7 +326,7 @@ class FileManager implements FileManagerInterface
 
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))), 'error', $logfile);
         $error = true;
 
         continue;
@@ -338,7 +339,7 @@ class FileManager implements FileManagerInterface
 
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename(\dirname($file))), 'error', $logfile);
         $error = true;
 
         continue;
@@ -361,7 +362,7 @@ class FileManager implements FileManagerInterface
 
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
         $error = true;
 
         continue;
@@ -381,7 +382,7 @@ class FileManager implements FileManagerInterface
 
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename), 'error', $logfile);
         $error = true;
 
         continue;
@@ -396,8 +397,8 @@ class FileManager implements FileManagerInterface
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()));
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()), 'error', 'jerror');
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()), 'error', $logfile);
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
         $error = true;
 
         continue;
@@ -409,15 +410,15 @@ class FileManager implements FileManagerInterface
         {
           // Debug info
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_ALREADY_EXISTING', $filename), 'error', $logfile);
         }
         else
         {
           // Debug info
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()));
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()), 'error', 'jerror');
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_FILESYSTEM_ERROR', $e->getMessage()), 'error', $logfile);
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_IMAGETYPE', $filename, $imagetype->typename), 'error', $logfile);
         }
 
         // Destroy the IMGtools service
@@ -440,7 +441,7 @@ class FileManager implements FileManagerInterface
     if($error)
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'));
-      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', 'jerror');
+      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', $logfile);
 
       return false;
     }
@@ -451,13 +452,14 @@ class FileManager implements FileManagerInterface
   /**
    * Deletion of image types
    *
-   * @param   object|int|string    $img    Image object, image ID or image alias
+   * @param   object|int|string    $img       Image object, image ID or image alias
+   * @param   string               $logfile   Name of the logfile to use
    * 
    * @return  bool                 True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function deleteImages($img): bool
+  public function deleteImages($img, $logfile = 'jerror'): bool
   {
     // Loop through all imagetypes
     $error = false;
@@ -485,7 +487,7 @@ class FileManager implements FileManagerInterface
         {
           // Deletion failed
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_IMAGETYPE', \basename($file), $imagetype->typename));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_IMAGETYPE', \basename($file), $imagetype->typename), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_IMAGETYPE', \basename($file), $imagetype->typename), 'error', $logfile);
           $error = true;
 
           continue;
@@ -499,7 +501,7 @@ class FileManager implements FileManagerInterface
     if($error)
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'));
-      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', 'jerror');
+      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', $logfile);
 
       return false;
     }
@@ -510,13 +512,14 @@ class FileManager implements FileManagerInterface
   /**
    * Checks image types for existence, validity and size
    *
-   * @param   object|int|string    $img    Image object, image ID or image alias
+   * @param   object|int|string    $img       Image object, image ID or image alias
+   * @param   string               $logfile   Name of the logfile to use
    * 
    * @return  array                List of filetype info
    * 
    * @since   4.0.0
    */
-  public function checkImages($img): array
+  public function checkImages($img, $logfile = 'jerror'): array
   {
     $images = array();
 
@@ -535,7 +538,7 @@ class FileManager implements FileManagerInterface
       {
         // File not found
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')', 'error', 'jerror');
+        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')', 'error', $logfile);
 
         return false;
       }
@@ -545,7 +548,7 @@ class FileManager implements FileManagerInterface
         {
           // File not found
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')');
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')', 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file).' ('.$imagetype->typename.')', 'error', $logfile);
         }
         else
         {
@@ -567,12 +570,13 @@ class FileManager implements FileManagerInterface
    * @param   object|int|string    $dest       Category object, ID or alias of the destination category
    * @param   string|false         $filename   Filename of the moved image (default: false)
    * @param   bool                 $copy       True, if you want to copy the images (default: false)
+   * @param   string               $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function moveImages($img, $dest, $filename=false, $copy=false): bool
+  public function moveImages($img, $dest, $filename=false, $copy=false, $logfile='jerror'): bool
   {
     // Switch method
     $method = 'MOVE';
@@ -615,7 +619,7 @@ class FileManager implements FileManagerInterface
       {
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $folder_dst));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $folder_dst), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $folder_dst), 'error', $logfile);
         $error = true;
 
         continue;
@@ -625,7 +629,7 @@ class FileManager implements FileManagerInterface
       {
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename($folder_dst)));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename($folder_dst)), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', \basename($folder_dst)), 'error', $logfile);
         $error = true;
 
         continue;
@@ -647,7 +651,7 @@ class FileManager implements FileManagerInterface
       {
         // File not found
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($img_src).' ('.$imagetype->typename.')');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING'.', '.\basename($img_src).' ('.$imagetype->typename.')'), 'error', 'jerror');
+        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($img_src).' ('.$imagetype->typename.')', 'error', $logfile);
         $error = true;
 
         continue;
@@ -656,7 +660,7 @@ class FileManager implements FileManagerInterface
       {
         // Operation failed
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_IMAGETYPE', \basename($img_src), $imagetype->typename));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_IMAGETYPE', \basename($img_src), $imagetype->typename), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_IMAGETYPE', \basename($img_src), $imagetype->typename), 'error', $logfile);
         $error = true;
 
         continue;
@@ -669,7 +673,7 @@ class FileManager implements FileManagerInterface
     if($error)
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'));
-      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', 'jerror');
+      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', $logfile);
 
       return false;
     }
@@ -683,14 +687,15 @@ class FileManager implements FileManagerInterface
    * @param   object|int|string    $img        Image object, image ID or image alias
    * @param   object|int|string    $dest       Category object, ID or alias of the destination category
    * @param   string|false         $filename   Filename of the moved image (default: False)
+   * @param   string               $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function copyImages($img, $dest, $filename=false): bool
+  public function copyImages($img, $dest, $filename=false, $logfile='jerror'): bool
   {
-    return $this->moveImages($img, $dest, $filename, true);
+    return $this->moveImages($img, $dest, $filename, true, $logfile);
   }
 
   /**
@@ -698,12 +703,13 @@ class FileManager implements FileManagerInterface
    *
    * @param   object|int|string   $img        Image object, image ID or image alias
    * @param   string              $filename   New filename of the image
+   * @param   string              $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function renameImages($img, $filename): bool
+  public function renameImages($img, $filename, $logfile = 'jerror'): bool
   {
     // Loop through all imagetypes
     $error = false;
@@ -730,7 +736,7 @@ class FileManager implements FileManagerInterface
       {
         // File not found
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file_orig).' ('.$imagetype->typename.')');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file_orig).' ('.$imagetype->typename.')', 'error', 'jerror');
+        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING').', '.\basename($file_orig).' ('.$imagetype->typename.')', 'error', $logfile);
         $error = true;
 
         continue;
@@ -748,7 +754,7 @@ class FileManager implements FileManagerInterface
     {
       // Renaming failed
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_RENAME_IMAGE', \basename($file_orig)));
-      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_RENAME_IMAGE', \basename($file_orig)), 'warning', 'jerror');
+      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_RENAME_IMAGE', \basename($file_orig)), 'warning', $logfile);
 
       return false;
     }
@@ -764,12 +770,13 @@ class FileManager implements FileManagerInterface
    *
    * @param   string              $foldername   Name of the folder to be created
    * @param   object|int|string   $parent       Object, ID or alias of the parent category (default: 1)
+   * @param   string              $logfile      Name of the logfile to use
    * 
    * @return  bool                True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function createCategory($foldername, $parent=1): bool
+  public function createCategory($foldername, $parent=1, $logfile='jerror'): bool
   {
     // Loop through all imagetypes
     $error       = false;
@@ -798,7 +805,7 @@ class FileManager implements FileManagerInterface
         else
         {
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername));
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername), 'error', $logfile);
           $error = true;
         }
 
@@ -809,7 +816,7 @@ class FileManager implements FileManagerInterface
       {
         // Debug info
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY', $foldername), 'error', $logfile);
         $error = true;
 
         continue;
@@ -822,7 +829,7 @@ class FileManager implements FileManagerInterface
     if($error)
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'));
-      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', 'jerror');
+      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', $logfile);
 
       return false;
     }
@@ -841,12 +848,13 @@ class FileManager implements FileManagerInterface
    *
    * @param   object|int|string   $cat          Object, ID or alias of the category to be deleted
    * @param   bool                $del_images   True, if you want to delete even if there are still images in it (default: false)
+   * @param   string              $logfile      Name of the logfile to use
    * 
    * @return  bool                True on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function deleteCategory($cat, $del_images=false): bool
+  public function deleteCategory($cat, $del_images=false, $logfile='jerror'): bool
   {
     $error = false;
     // Loop through all imagetypes
@@ -864,7 +872,7 @@ class FileManager implements FileManagerInterface
       {
         // Folder not found
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.\basename($path).')');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.\basename($path).')', 'error', 'jerror');
+        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.\basename($path).')', 'error', $logfile);
 
         return false;
       }
@@ -879,11 +887,11 @@ class FileManager implements FileManagerInterface
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)));
           if(\is_object($cat) && \property_exists($cat, 'path'))
           {
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat->id, 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat->id, 'error', $logfile);
           }
           else
           {
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat, 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat, 'error', $logfile);
           }
 
           return false;
@@ -895,11 +903,11 @@ class FileManager implements FileManagerInterface
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)));
           if(\is_object($cat) && \property_exists($cat, 'path'))
           {
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat->id, 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat->id, 'error', $logfile);
           }
           else
           {
-            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat, 'error', 'jerror');
+            $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY_NOTEMPTY', \basename($path)) . '; Category ID: ' . $cat, 'error', $logfile);
           }
 
           return false;
@@ -919,7 +927,7 @@ class FileManager implements FileManagerInterface
       {
         // Deletion failed
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY', \basename($path)));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY', \basename($path)), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY', \basename($path)), 'error', $logfile);
         $error = true;
 
         continue;
@@ -929,7 +937,7 @@ class FileManager implements FileManagerInterface
     if($error)
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'));
-      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', 'jerror');
+      $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_SOME_ERRORS_IMAGEFILE'), 'error', $logfile);
 
       return false;
     }
@@ -943,13 +951,14 @@ class FileManager implements FileManagerInterface
   /**
    * Checks a category for existence, correct images and file path
    *
-   * @param   object|int|string   $cat    Object, ID or alias of the category to be checked
+   * @param   object|int|string   $cat       Object, ID or alias of the category to be checked
+   * @param   string              $logfile   Name of the logfile to use
    * 
    * @return  array               List of folder info
    * 
    * @since   4.0.0
    */
-  public function checkCategory($cat): array
+  public function checkCategory($cat, $logfile='jerror'): array
   {
     $folders = array();
 
@@ -968,7 +977,7 @@ class FileManager implements FileManagerInterface
       {
         // Folder not found
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.basename($path).')');
-        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.basename($path).')', 'error', 'jerror');
+        $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING').' ('.basename($path).')', 'error', $logfile);
 
         return false;
       }
@@ -984,12 +993,13 @@ class FileManager implements FileManagerInterface
    * @param   object|int|string   $dest         Category object, ID or alias of the destination category
    * @param   string|false        $foldername   Foldername of the moved category (default: false)
    * @param   bool                $copy         True, if you want to copy the category (default: false)
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function moveCategory($cat, $dest, $foldername=false, $copy=false): bool
+  public function moveCategory($cat, $dest, $foldername=false, $copy=false, $logfile='jerror'): bool
   {
     // Switch method
     $method = 'MOVE';
@@ -1038,7 +1048,7 @@ class FileManager implements FileManagerInterface
       {
         // Folder not found
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $src_path));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $src_path), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $src_path), 'error', $logfile);
         $error = true;
 
         continue;
@@ -1056,7 +1066,7 @@ class FileManager implements FileManagerInterface
     {
       // Moving failed
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_CATEGORY', \basename($src_path)));
-      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_CATEGORY', \basename($src_path)), 'error', 'jerror');
+      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_'.$method.'_CATEGORY', \basename($src_path)), 'error', $logfile);
 
       return false;
     }
@@ -1072,12 +1082,13 @@ class FileManager implements FileManagerInterface
    *
    * @param   object|int|string   $cat          Object, ID or alias of the category to be renamed
    * @param   string              $foldername   New foldername of the category
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function renameCategory($cat, $foldername): bool
+  public function renameCategory($cat, $foldername, $logfile='jerror'): bool
   {
     // Create path for messages
     $this->paths['src']  = '[ROOT]'.\DIRECTORY_SEPARATOR.$this->getCatPath($cat);
@@ -1102,7 +1113,7 @@ class FileManager implements FileManagerInterface
       {
         // Folder not found
         $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $folder_orig));
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $folder_orig), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_ERROR_FOLDER_NOT_EXISTING', $folder_orig), 'error', $logfile);
         $error = true;
 
         continue;
@@ -1137,14 +1148,15 @@ class FileManager implements FileManagerInterface
    * @param   object|int|string   $cat          Object, ID or alias of the category to be copied
    * @param   object|int|string   $dest         Category object, ID or alias of the destination category
    * @param   string|false        $foldername   Foldername of the moved category (default: false)
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function copyCategory($cat, $dest, $foldername=false): bool
+  public function copyCategory($cat, $dest, $foldername=false, $logfile='jerror'): bool
   {
-    return $this->moveCategory($cat, $dest, $foldername, true);
+    return $this->moveCategory($cat, $dest, $foldername, true, $logfile);
   }
 
   /**
@@ -1155,12 +1167,13 @@ class FileManager implements FileManagerInterface
    * @param   object|int|string|bool    $catid     Category object, category ID, category alias or category path (default: false)
    * @param   string|bool               $filename  The filename (default: false)
    * @param   boolean                   $root      True to add the system root to the path
+   * @param   string                    $logfile   Name of the logfile to use
    * 
    * @return  mixed   Path to the image on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function getImgPath($img, $type, $catid=false, $filename=false, $root=false)
+  public function getImgPath($img, $type, $catid=false, $filename=false, $root=false, $logfile='jerror')
   {
     if($catid === false || $filename === false)
     {
@@ -1179,7 +1192,7 @@ class FileManager implements FileManagerInterface
         if($img === false || \is_null($img->id))
         {
           $this->app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETIMGPATH', $img), 'error');
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETIMGPATH', $img), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETIMGPATH', $img), 'error', $logfile);
 
           return false;
         }
@@ -1205,7 +1218,7 @@ class FileManager implements FileManagerInterface
         }
 
         $this->app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Image'), 'error');
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Image'), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Image'), 'error', $logfile);
 
         return false;
       }
@@ -1239,13 +1252,14 @@ class FileManager implements FileManagerInterface
    * @param   string|bool              $alias           The category alias (default: false)
    * @param   boolean                  $root            True to add the system root to the path
    * @param   boolean                  $compatibility   Take into account the compatibility mode when creating the path
+   * @param   string                   $logfile         Name of the logfile to use
    * 
    * 
    * @return  mixed   Path to the category on success, false otherwise
    * 
    * @since   4.0.0
    */
-  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=false, $compatibility=true)
+  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=false, $compatibility=true, $logfile='jerror')
   {
     // We got a valid category object
     if(\is_object($cat) && \property_exists($cat, 'path'))
@@ -1271,7 +1285,7 @@ class FileManager implements FileManagerInterface
       if($cat === false)
       {
         $this->app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $cat), 'error');
-        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $cat), 'error', 'jerror');
+        $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $cat), 'error', $logfile);
 
         return false;
       }
@@ -1312,7 +1326,7 @@ class FileManager implements FileManagerInterface
         if($parent === false)
         {
           $this->app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $parent), 'error');
-          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $parent), 'error', 'jerror');
+          $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETCATPATH', $parent), 'error', $logfile);
 
           return false;
         }
@@ -1331,7 +1345,7 @@ class FileManager implements FileManagerInterface
     else
     {
       $this->app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Category'), 'error');
-      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Category'), 'error', 'jerror');
+      $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_GETPATH_NOQUERY', 'Category'), 'error', $logfile);
 
       return false;
     }
@@ -1398,12 +1412,13 @@ class FileManager implements FileManagerInterface
    * Input is a filename generated from genFilename()
    *
    * @param   string    $filename     Original filename created from genFilename()
+   * @param   string    $logfile      Name of the logfile to use
    *
    * @return  string    The generated filename
    *
    * @since   4.0.0
    */
-  public function regenFilename($filename): string
+  public function regenFilename($filename, $logfile='jerror'): string
   {
     $filecounter  = null;
     $filename_arr = \explode('_', $filename);
@@ -1419,7 +1434,7 @@ class FileManager implements FileManagerInterface
     }
     else
     {
-      $this->component->addLog('Invalid filename received. Please make sure filename has the correct form.', 'error', 'jerror');
+      $this->component->addLog('Invalid filename received. Please make sure filename has the correct form.', 'error', $logfile);
       throw new \Exception('Invalid filename received. Please make sure filename has the correct form.');
     }
     list($rnd, $tag) = \explode('.', $end);

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
@@ -35,34 +35,37 @@ interface FileManagerInterface
    * @param   bool                 $processing    True to create imagetypes by processing source (defualt: True)
    * @param   bool                 $local_source  True if the source is a file located in a local folder (default: True)
    * @param   array                $skip          List of imagetypes to skip creation (default: [])
+   * @param   string               $logfile       Name of the logfile to use
    * 
    * @return  bool                 True on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function createImages($source, $filename, $cat=2, $processing=True, $local_source=True, $skip=[]): bool;
+  public function createImages($source, $filename, $cat=2, $processing=True, $local_source=True, $skip=[], $logfile = 'jerror'): bool;
 
   /**
    * Deletion of image types
    *
-   * @param   object|int|string    $img    Image object, image ID or image alias
-   *
+   * @param   object|int|string    $img       Image object, image ID or image alias
+   * @param   string               $logfile   Name of the logfile to use
+   * 
    * @return  bool                 True on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function deleteImages($img): bool;
+  public function deleteImages($img, $logfile = 'jerror'): bool;
 
   /**
    * Checks image types for existence, validity and size
    *
-   * @param   object|int|string    $img    Image object, image ID or image alias
-   *
+   * @param   object|int|string    $img       Image object, image ID or image alias
+   * @param   string               $logfile   Name of the logfile to use
+   * 
    * @return  array                List of filetype info
-   *
+   * 
    * @since   4.0.0
    */
-  public function checkImages($img): array;
+  public function checkImages($img, $logfile = 'jerror'): array;
 
   /**
    * Move image files from one category to another
@@ -71,12 +74,13 @@ interface FileManagerInterface
    * @param   object|int|string    $dest       Category object, ID or alias of the destination category
    * @param   string|false         $filename   Filename of the moved image (default: false)
    * @param   bool                 $copy       True, if you want to copy the images (default: false)
+   * @param   string               $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function moveImages($img, $dest, $filename=false, $copy=false): bool;
+  public function moveImages($img, $dest, $filename=false, $copy=false, $logfile='jerror'): bool;
 
   /**
    * Copy image files from one category to another
@@ -84,59 +88,64 @@ interface FileManagerInterface
    * @param   object|int|string    $img        Image object, image ID or image alias
    * @param   object|int|string    $dest       Category object, ID or alias of the destination category
    * @param   string|false         $filename   Filename of the moved image (default: False)
+   * @param   string               $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function copyImages($img, $dest, $filename=false): bool;
+  public function copyImages($img, $dest, $filename=false, $logfile='jerror'): bool;
 
   /**
    * Rename files of image
    *
    * @param   object|int|string   $img        Image object, image ID or image alias
    * @param   string              $filename   New filename of the image
+   * @param   string              $logfile    Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function renameImages($img, $filename): bool;
+  public function renameImages($img, $filename, $logfile = 'jerror'): bool;
 
   /**
    * Creation of a category
    *
    * @param   string              $foldername   Name of the folder to be created
    * @param   object|int|string   $parent       Object, ID or alias of the parent category (default: 1)
-   *
+   * @param   string              $logfile      Name of the logfile to use
+   * 
    * @return  bool                True on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function createCategory($foldername, $parent=1): bool;
+  public function createCategory($foldername, $parent=1, $logfile='jerror'): bool;
 
   /**
    * Deletion of a category
    *
    * @param   object|int|string   $cat          Object, ID or alias of the category to be deleted
    * @param   bool                $del_images   True, if you want to delete even if there are still images in it (default: false)
-   *
+   * @param   string              $logfile      Name of the logfile to use
+   * 
    * @return  bool                True on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function deleteCategory($cat, $del_images=false): bool;
+  public function deleteCategory($cat, $del_images=false, $logfile='jerror'): bool;
 
   /**
    * Checks a category for existence, correct images and file path
    *
-   * @param   object|int|string   $cat    Object, ID or alias of the category to be checked
-   *
+   * @param   object|int|string   $cat       Object, ID or alias of the category to be checked
+   * @param   string              $logfile   Name of the logfile to use
+   * 
    * @return  array               List of folder info
-   *
+   * 
    * @since   4.0.0
    */
-  public function checkCategory($cat): array;
+  public function checkCategory($cat, $logfile='jerror'): array;
 
   /**
    * Copy category with all images from one parent category to another
@@ -144,12 +153,13 @@ interface FileManagerInterface
    * @param   object|int|string   $cat          Object, ID or alias of the category to be copied
    * @param   object|int|string   $dest         Category object, ID or alias of the destination category
    * @param   string|false        $foldername   Foldername of the moved category (default: false)
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function copyCategory($cat, $dest, $foldername=false): bool;
+  public function copyCategory($cat, $dest, $foldername=false, $logfile='jerror'): bool;
 
   /**
    * Move category with all images from one parent category to another
@@ -158,24 +168,26 @@ interface FileManagerInterface
    * @param   object|int|string   $dest         Category object, ID or alias of the destination category
    * @param   string|false        $foldername   Foldername of the moved category (default: false)
    * @param   bool                $copy         True, if you want to copy the category (default: false)
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function moveCategory($cat, $dest, $foldername=false, $copy=false): bool;
+  public function moveCategory($cat, $dest, $foldername=false, $copy=false, $logfile='jerror'): bool;
 
   /**
    * Rename folder of category
    *
    * @param   object|int|string   $cat          Object, ID or alias of the category to be renamed
    * @param   string              $foldername   New foldername of the category
+   * @param   string              $logfile      Name of the logfile to use
    *
    * @return  bool    true on success, false otherwise
    *
    * @since   4.0.0
    */
-  public function renameCategory($cat, $foldername): bool;
+  public function renameCategory($cat, $foldername, $logfile='jerror'): bool;
 
   /**
    * Returns the path to an image
@@ -184,29 +196,32 @@ interface FileManagerInterface
    * @param   string                    $type      Imagetype
    * @param   object|int|string|bool    $catid     Category object, category ID, category alias or category path (default: false)
    * @param   string|bool               $filename  The filename (default: false)
-   * @param   integer                   $root      The root to use / 0:no root, 1:local root, 2:storage root (default: 0)
-   *
+   * @param   boolean                   $root      True to add the system root to the path
+   * @param   string                    $logfile   Name of the logfile to use
+   * 
    * @return  mixed   Path to the image on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function getImgPath($img, $type, $catid=false, $filename=false, $root=0);
+  public function getImgPath($img, $type, $catid=false, $filename=false, $root=false, $logfile='jerror');
 
   /**
    * Returns the path to a category without root path.
    *
-   * @param   object|int|string        $cat       Category object, category ID or category alias (new categories: ID=0)
-   * @param   string|bool              $type      Imagetype if needed
-   * @param   object|int|string|bool   $parent    Parent category object, parent category ID, parent category alias or parent category path (default: false)
-   * @param   string|bool              $alias     The category alias (default: false)
-   * @param   int                      $root      The root to use / 0:no root, 1:local root, 2:storage root (default: 0)
-   *
-   *
+   * @param   object|int|string        $cat             Category object, category ID or category alias (new categories: ID=0)
+   * @param   string|bool              $type            Imagetype if needed
+   * @param   object|int|string|bool   $parent          Parent category object, parent category ID, parent category alias or parent category path (default: false)
+   * @param   string|bool              $alias           The category alias (default: false)
+   * @param   boolean                  $root            True to add the system root to the path
+   * @param   boolean                  $compatibility   Take into account the compatibility mode when creating the path
+   * @param   string                   $logfile         Name of the logfile to use
+   * 
+   * 
    * @return  mixed   Path to the category on success, false otherwise
-   *
+   * 
    * @since   4.0.0
    */
-  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=0);
+  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=false, $compatibility=true, $logfile='jerror');
 
   /**
    * Generates image filenames
@@ -227,10 +242,11 @@ interface FileManagerInterface
    * Input is a filename generated from genFilename()
    *
    * @param   string    $filename     Original filename created from genFilename()
+   * @param   string    $logfile      Name of the logfile to use
    *
    * @return  string    The generated filename
    *
    * @since   4.0.0
    */
-  public function regenFilename($filename): string;
+  public function regenFilename($filename, $logfile='jerror'): string;
 }

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -911,7 +911,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
               $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type));
               $this->component->addLog('Jg3ToJg4 - ' . 'Action File::copy: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
               $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
-              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \dirname($img_src)), 'error', 'migration');
               $error = true;
               continue;
             }
@@ -923,7 +923,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
               $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type));
               $this->component->addLog('Jg3ToJg4 - ' . 'Action File::move: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
               $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
-              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \dirname($img_src)), 'error', 'migration');
               $error = true;
               continue;
             }
@@ -949,14 +949,14 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type));
           $this->component->addLog('Jg3ToJg4 - ' . 'Action copy: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
           $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
-          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \dirname($img_src)), 'error', 'migration');
         }
         else
         {
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type));
           $this->component->addLog('Jg3ToJg4 - ' . 'Action move: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
           $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
-          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \dirname($img_src)), 'error', 'migration');
         }
 
         $error = true;

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -700,7 +700,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
         $tmp_cat->path = \substr($cat->path, 0, strrpos($cat->path, \basename($cat->path))) . $oldName;
 
         // Rename existing folders
-        return $this->component->getFileManager()->renameCategory($tmp_cat, $newName);
+        return $this->component->getFileManager()->renameCategory($tmp_cat, $newName, 'migration');
       }
     }
     else
@@ -709,7 +709,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
       if($this->params->get('new_dirs', 1) == 1)
       {
         // Create new/JG4 folder structure (based on alias)
-        return $this->component->getFileManager()->createCategory($cat->alias, $cat->parent_id);
+        return $this->component->getFileManager()->createCategory($cat->alias, $cat->parent_id, 'migration');
       }
       else
       {
@@ -725,7 +725,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
           return false;
         }
 
-        return $this->component->getFileManager()->createCategory(\basename($cat->static_path), $cat->parent_id);
+        return $this->component->getFileManager()->createCategory(\basename($cat->static_path), $cat->parent_id, 'migration');
       }
     }
 
@@ -823,7 +823,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
     $migrated_catid = $migrated_cats->get($img->catid);
 
     // Create imagetypes
-    return $this->component->getFileManager()->createImages($source, $img->filename, $migrated_catid);
+    return $this->component->getFileManager()->createImages($source, $img->filename, $migrated_catid, true, true, [], 'migration');
   }
 
   /**
@@ -910,7 +910,8 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
             {
               $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type));
               $this->component->addLog('Jg3ToJg4 - ' . 'Action File::copy: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
-              $this->component->addLog('Jg3ToJg4 - ' . 'Check whether the file is available in the source.', 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
               $error = true;
               continue;
             }
@@ -921,7 +922,8 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
             {
               $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type));
               $this->component->addLog('Jg3ToJg4 - ' . 'Action File::move: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
-              $this->component->addLog('Jg3ToJg4 - ' . 'Check whether the file is available in the source.', 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
+              $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
               $error = true;
               continue;
             }
@@ -946,13 +948,15 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
         {
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type));
           $this->component->addLog('Jg3ToJg4 - ' . 'Action copy: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
-          $this->component->addLog('Jg3ToJg4 - ' . 'Check whether the file is available in the source.', 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
         }
         else
         {
           $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type));
           $this->component->addLog('Jg3ToJg4 - ' . 'Action move: ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_ERROR_MOVE_IMAGETYPE', \basename($img_src), $type), 'error', 'migration');
-          $this->component->addLog('Jg3ToJg4 - ' . 'Check whether the file is available in the source.', 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT'), 'error', 'migration');
+          $this->component->addLog('Jg3ToJg4 - ' . Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH', \basename($img_src)), 'error', 'migration');
         }
 
         $error = true;


### PR DESCRIPTION
This PR adjusts the way error logging is done during migration. This will add some important information when there is an error happening in the file manager service.

### How to test this PR
- Migration should still work as before
- In case of an error when dealing with the filesystem, the log file should contain more and useful information.