### PR TITLE
Add language constants

### DIFF
--- a/site/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/site/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -139,6 +139,10 @@ COM_JOOMGALLERY_CATEGORY_BUTTON_UNLOCK="Unlock"
 COM_JOOMGALLERY_CATEGORY_PASSWORD_INCORRECT="Incorrect password"
 COM_JOOMGALLERY_IMAGES_VIEW_NO_ACCESS="This user is not allowed to view the administration view: List of Images"
 COM_JOOMGALLERY_CATEGORIES_VIEW_NO_ACCESS="This user is not allowed to view the administration view: List of Categories"
+COM_JOOMGALLERY_CATEGORY_BACK_TO_PARENT="Back to: Parent Category"
+COM_JOOMGALLERY_CATEGORY_NO_ELEMENTS="No elements in this category..."
+COM_JOOMGALLERY_GALLERY_NO_IMAGES="No images in the gallery..."
+COM_JOOMGALLERY_IMAGE_BACK_TO_CATEGORY="Back to: Category"
 
 ;Configuration
 COM_JOOMGALLERY_CONFIG_TYPEPARAMS_INFO="Current global parameter is calculated based on the Configuration Set of the current user.<br />The parameter applied in the end may be different!"

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -136,7 +136,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php // Back to parent category ?>
 <?php if($this->item->parent_id > 0) : ?>
   <a class="jg-link btn btn-outline-primary" href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $this->item->parent_id); ?>">
-    <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('Back to: Parent Category'); ?></span>
+    <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_BACK_TO_PARENT'); ?></span>
   </a>
 <?php endif; ?>
 
@@ -190,7 +190,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 
 <?php // Hint for no items ?>
 <?php if(count($this->item->children->items) == 0 && count($this->item->images->items) == 0) : ?>
-  <p><?php echo Text::_('No elements in this category...') ?></p>
+  <p><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_NO_ELEMENTS') ?></p>
 <?php endif; ?>
 
 <?php // Subcategories ?>

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -84,7 +84,7 @@ $wa->useScript('com_joomgallery.joomgrid');
 
   <?php // Hint for no items ?>
   <?php if(count($this->item->images->items) == 0) : ?>
-    <p><?php echo Text::_('No images in the gallery...') ?></p>
+    <p><?php echo Text::_('COM_JOOMGALLERY_GALLERY_NO_IMAGES') ?></p>
   <?php else: ?>
     <?php // Display data array for grid layout
     $imgsData = [ 'id' => (int) $this->item->id, 'layout' => $gallery_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -64,7 +64,7 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 <?php endif; ?>
 
 <a class="jg-link btn btn-outline-primary" href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $this->item->catid); ?>">
-  <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('Back to: Category') . ' ' . $this->item->cattitle; ?></span>
+  <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('COM_JOOMGALLERY_IMAGE_BACK_TO_CATEGORY') . ' ' . $this->item->cattitle; ?></span>
 </a>
 
 </br />


### PR DESCRIPTION
In some places in the frontend, 'fixed texts' are displayed instead of language constants. Therefore, these places cannot be translated in other languages.

This PR adds language constants in the following places:
'Back to: Parent Category' -> COM_JOOMGALLERY_CATEGORY_BACK_TO_PARENT
'No elements in this category...' -> COM_JOOMGALLERY_CATEGORY_NO_ELEMENTS
'No images in the gallery...' -> COM_JOOMGALLERY_GALLERY_NO_IMAGES
'Back to: Category' -> COM_JOOMGALLERY_IMAGE_BACK_TO_CATEGORY