### PR TITLE
Fix: Move image to another filesystem

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -360,6 +360,7 @@ COM_JOOMGALLERY_ERROR_FILESYSTEM_ONLY_TOP_LEVEL_CAT="Not allowed to choose a ded
 COM_JOOMGALLERY_ERROR_FILESYSTEM_ONLY_EMPTY_CAT="Not allowed to change the filesystem for this category. Changing the filesystem only possible for empty categories (no images and no subcategories). You may consider a migration instead."
 COM_JOOMGALLERY_ERROR_MOVE_CATEGORY="There was a problem reorganizing the folders in the filesystem when moving the category. Therefore saving the item was canceled. Please check the filesystem manually and fix any discrepancies.<br>Folder path as it should be now: %s<br>Folder path as it should have been: %s"
 COM_JOOMGALLERY_ERROR_RENAME_CATEGORY="There was a problem reorganizing the folders in the filesystem when renaming the category. Therefore saving the item was canceled. Please check the filesystem manually and fix any discrepancies.<br>Folder path as it should be now: %s<br>Folder path as it should have been: %s"
+COM_JOOMGALLERY_ERROR_IMAGE_SAVE_TWO_FILESYSTEMS="Image could not be saved as there are two filesystems involved in saving process. Source filesystem: %s. Destination filesystem: %s."
 
 ;Mail Templates
 COM_JOOMGALLERY_MAIL_NEWIMAGE_TITLE="JoomGallery: New Image"

--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -46,6 +46,15 @@ class HtmlView extends JoomGalleryView
 		$this->item  = $this->get('Item');
 		$this->form  = $this->get('Form');
 
+		// JS to deactivate filesystem form field
+		$js  = 'var callback = function() {';
+		$js .=    'let catid = document.getElementById("jform_id");';
+		$js .=    'let filesystem = document.getElementById("jform_params__jg_filesystem");';
+		$js .=    'if(catid && filesystem && catid.value > 1) {filesystem.setAttribute("disabled", "disabled"); filesystem.classList.add("readonly");};';
+		$js .= '};';
+		$js .= 'if(document.readyState === "complete" || (document.readyState !== "loading" && !document.documentElement.doScroll)){callback();} else {document.addEventListener("DOMContentLoaded", callback);}';
+		$this->filesystem_js = $js;
+
 		// Check for errors.
 		if(count($errors = $this->get('Errors')))
 		{

--- a/administrator/com_joomgallery/tmpl/category/edit.php
+++ b/administrator/com_joomgallery/tmpl/category/edit.php
@@ -22,6 +22,13 @@ $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	 ->useScript('form.validate')
    ->useStyle('com_joomgallery.admin');
+
+// Add javascript to deactivate filesystem dropdown field
+if(property_exists($this, 'filesystem_js'))
+{
+  $wa->addInlineScript($this->filesystem_js);
+}
+
 HTMLHelper::_('bootstrap.tooltip');
 
 $app = Factory::getApplication();


### PR DESCRIPTION
This PR adds an error handling for the issue #342.

If you try to move or copy an image into a category with another filesystem, you will get an error and the save process is cancelled. This is not a proper fix, but it prevents corrupt datasets. For a proper fix, the filesystem service would have to be extended to support multiple filesystems. This can be implemented in a later release...

### How to test this PR
- When editing an existing category, the parameter field `jg_filesystem` has to be deactivated
- When changing the category of an existing image to a category having another filesystem set in its configuration, you will get an error and the image will not be saved.
- When copying a existing image and select a category having another filesystem set in its configuration, you will get an error and the image will not be saved.