### PR TITLE
Fix two frontend PHP errors

### DIFF
--- a/site/com_joomgallery/layouts/joomgallery/content/metadata.php
+++ b/site/com_joomgallery/layouts/joomgallery/content/metadata.php
@@ -20,8 +20,21 @@ $i = 0;
 <?php if(count((array) $exifData->get('exif.IFD0')) > 0) : ?>
   <ul class="metadata list-inline">
     <?php foreach($exifData->get('exif.IFD0') as $key => $value) : ?>
+      <?php
+        if(is_object($value))
+        {
+          // Get object properties as an array
+          $value = get_object_vars($value);
+        }
+        
+        if(is_array($value))
+        {
+          // Array to comma separated string
+          $value = implode(',', $value);
+        }
+      ?>
       <li class="list-inline-item metadata-<?php echo $key; ?> metadata-list<?php echo $i; ?>" itemprop="keywords">
-        <span><?php echo Text::_($key); ?></span>: <span><?php echo $this->escape($value); ?></span>,
+        <span><?php echo Text::_($key); ?></span>: <span><?php echo $this->escape($value); ?></span>;
       </li>
       <?php $i++; ?>
     <?php endforeach; ?>

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -348,7 +348,7 @@ class CategoryModel extends JoomItemModel
     $listModel->getState();
 
     // Select fields to load
-    $fields = array('id', 'alias', 'catid', 'title', 'description', 'filename', 'author', 'date', 'hits', 'votes', 'votesum');
+    $fields = array('id', 'alias', 'catid', 'title', 'description', 'filename', 'filesystem', 'author', 'date', 'hits', 'votes', 'votesum');
     $fields = $this->addColumnPrefix('a', $fields);
 
     // Apply preselected filters and fields selection for images

--- a/site/com_joomgallery/src/Model/GalleryModel.php
+++ b/site/com_joomgallery/src/Model/GalleryModel.php
@@ -116,7 +116,7 @@ class GalleryModel extends JoomItemModel
     $listModel->getState();
 
     // Select fields to load
-    $fields = array('id', 'alias', 'catid', 'title', 'description', 'filename', 'author', 'date', 'hits', 'votes', 'votesum');
+    $fields = array('id', 'alias', 'catid', 'title', 'description', 'filename', 'filesystem', 'author', 'date', 'hits', 'votes', 'votesum');
     $fields = $this->addColumnPrefix('a', $fields);
 
     // Apply preselected filters and fields selection for images


### PR DESCRIPTION
This PR fixes the fowllowing two frontend errors:
- Detail view: PHP error when having an array in some metadata values
- Category & Gallery view: PHP error when activating `Use real paths` in component configurations
(#356)

### How to test this PR
- [This image](https://drive.google.com/file/d/1hnef5zEADPxv7GFAuILAxLnbEOsr9Zwu/view?usp=sharing) creates an error in the single image view when this PR is not applied. No error with this PR.
- Activate `Use real paths` in component configurations and visit a category view containing at least one image.
