### PR TITLE
Sorting images category & gallery view

### DIFF
--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -504,6 +504,7 @@ class CategoryModel extends JoomItemModel
     $listModel->setState('list.start', $imgform_limitstart);
 
     // Apply ordering
+    $listModel->setState('list.ordering', '');
     $listModel->setState('list.fullordering', $params['configs']->get('jg_category_view_ord_images', 'a.date ASC', 'string'));
   }
 

--- a/site/com_joomgallery/src/Model/GalleryModel.php
+++ b/site/com_joomgallery/src/Model/GalleryModel.php
@@ -215,6 +215,7 @@ class GalleryModel extends JoomItemModel
     $listModel->setState('list.start', $imgform_limitstart);
 
     // Apply ordering
+    $listModel->setState('list.ordering', '');
     $listModel->setState('list.fullordering', $params['configs']->get('jg_gallery_view_ordering', 'a.hits DESC'));
   }
 


### PR DESCRIPTION
This PR fixes the issue reported in #355

### How to test this PR
The ordering configuration parameter `jg_category_view_ord_images` and `jg_gallery_view_ordering` should now have an effect on the ordering in the category and the gallery view in the frontend.