### PR TITLE
Add deleteSource() method to Migration script

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -892,6 +892,7 @@ COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_END_MIGRATE="Migration of the record ended
 COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_CONCELLED="Migration of the record cancelled! ID: %s"
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_FOLDERS="Source directories could not be deleted. Check the log file and delete the failed directories manually."
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_TABLES="Source DB tables could not be deleted. Check the log file and delete the failed tables manually."
+COM_JOOMGALLERY_SERVICE_MIGRATION_MANUALLY_DELETE_SOURCE_FOLDERS="Your migration settings do not allow the script to automatically delete the source directories and files. Treat the following folders manually: %s"
 
 ;Menu
 COM_JOOMGALLERY_MENU_CATEGORY_VIEW_OPTIONS="Category View"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -890,6 +890,8 @@ COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_TXT="Check whether the fi
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_FILE_NOT_FOUND_PATH="Path where the file is looked for: %s"
 COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_END_MIGRATE="Migration of the record ended. Type: %s; Source ID: %s"
 COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_CONCELLED="Migration of the record cancelled! ID: %s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_FOLDERS="Source directories could not be deleted. Check the log file and delete the failed directories manually."
+COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_TABLES="Source DB tables could not be deleted. Check the log file and delete the failed tables manually."
 
 ;Menu
 COM_JOOMGALLERY_MENU_CATEGORY_VIEW_OPTIONS="Category View"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -892,7 +892,7 @@ COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_END_MIGRATE="Migration of the record ended
 COM_JOOMGALLERY_SERVICE_MIGRATION_LOG_CONCELLED="Migration of the record cancelled! ID: %s"
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_FOLDERS="Source directories could not be deleted. Check the log file and delete the failed directories manually."
 COM_JOOMGALLERY_SERVICE_MIGRATION_ERROR_DELETE_SOURCE_TABLES="Source DB tables could not be deleted. Check the log file and delete the failed tables manually."
-COM_JOOMGALLERY_SERVICE_MIGRATION_MANUALLY_DELETE_SOURCE_FOLDERS="Your migration settings do not allow the script to automatically delete the source directories and files. Treat the following folders manually: %s"
+COM_JOOMGALLERY_SERVICE_MIGRATION_MANUALLY_DELETE_SOURCE_FOLDERS="Your migration settings do not allow the script to automatically delete the source directories and files. Treat the folders of the following imagetypes manually: %s"
 
 ;Menu
 COM_JOOMGALLERY_MENU_CATEGORY_VIEW_OPTIONS="Category View"

--- a/administrator/com_joomgallery/src/Controller/JoomAdminController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomAdminController.php
@@ -129,7 +129,7 @@ class JoomAdminController extends BaseAdminController
     }
 
     // Guess context if needed
-    if(empty($this->context))
+    if(empty($this->context) || ($this->context && \strpos($this->context, $task) === false))
     {
       $this->context = _JOOM_OPTION . '.' . $this->name;
 

--- a/administrator/com_joomgallery/src/Controller/JoomFormController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomFormController.php
@@ -198,7 +198,15 @@ class JoomFormController extends BaseFormController
    */
   protected function allowAdd($data = [])
   {
-    switch($this->context)
+    $parts = \explode('.', $this->context);
+    $key   = 0;
+
+    if(\strpos($parts[0], 'com_') !== false)
+    {
+      $key = 1;
+    }
+
+    switch($parts[$key])
     {
       case 'category':
         if($this->task == 'add')

--- a/administrator/com_joomgallery/src/Controller/JoomFormController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomFormController.php
@@ -119,7 +119,7 @@ class JoomFormController extends BaseFormController
     }
 
     // Guess context if needed
-    if(empty($this->context))
+    if(empty($this->context) || ($this->context && \strpos($this->context, $task) === false))
     {
       $this->context = _JOOM_OPTION . '.' . $this->name;
 

--- a/administrator/com_joomgallery/src/Controller/JoomFormController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomFormController.php
@@ -158,6 +158,35 @@ class JoomFormController extends BaseFormController
   }
 
   /**
+   * Method to get a model object, loading it if required.
+   *
+   * @param   string  $name    The model name. Optional.
+   * @param   string  $prefix  The class prefix. Optional.
+   * @param   array   $config  Configuration array for model. Optional.
+   *
+   * @return  BaseDatabaseModel  The model.
+   *
+   * @since   4.0.0
+   */
+  public function getModel($name = '', $prefix = '', $config = ['ignore_request' => true])
+  {
+    if(empty($name))
+    {
+      $parts = \explode('.', $this->context);
+      $key   = 0;
+
+      if(\strpos($parts[0], 'com_') !== false)
+      {
+        $key = 1;
+      }
+
+      $name = $parts[$key];
+    }
+
+    return parent::getModel($name, $prefix, $config);
+  }
+
+  /**
    * Method to check if you can add a new record.   *
    * Extended classes can override this if necessary.
    *

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -135,7 +135,7 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
     }
 
     // Guess context if needed
-    if(empty($this->context))
+    if(empty($this->context) || ($this->context && \strpos($this->context, $task) === false))
     {
       $this->context = _JOOM_OPTION . '.' . $this->name;
 

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -436,11 +436,6 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
         $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_SOURCE_DATA_DELETE_SUCCESSFUL'), 'message');
         $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_MIGRATION_SOURCE_DATA_DELETE_SUCCESSFUL'), 'info', 'jerror');
       }
-      else
-      {
-        $this->app->enqueueMessage($model->getError(), 'error');
-        $this->component->addLog($model->getError(), 'error', 'jerror');
-      }
     }
 
     // Redirect to the step 4 screen.

--- a/administrator/com_joomgallery/src/Extension/MessageTrait.php
+++ b/administrator/com_joomgallery/src/Extension/MessageTrait.php
@@ -44,7 +44,7 @@ trait MessageTrait
    *
    * @var array
   */
-  public $rawTasks = array('image.ajaxsave', 'tags.searchajax');
+  public $rawTasks = array('image.ajaxsave', 'tags.searchajax', 'migration.start');
 
   /**
 	 * Session storage path

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -15,9 +15,9 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Table\Table;
+use \Joomla\Filesystem\Path;
 use \Joomla\Registry\Registry;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\Path;
 use \Joomla\Database\DatabaseFactory;
 use \Joomla\Database\DatabaseInterface;
 use \Joomla\Component\Media\Administrator\Exception\FileNotFoundException;

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -848,12 +848,35 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
 
     // Retrieve a list of source tables
     list($db, $dbPrefix) = $this->getDB('source');
-    $tables = $this->getSourceTables();
+    $tables = array( '#__joomgallery',
+                     '#__joomgallery_catg',
+                     '#__joomgallery_category_details',
+                     '#__joomgallery_comments',
+                     '#__joomgallery_config',
+                     '#__joomgallery_countstop',
+                     '#__joomgallery_image_details',
+                     '#__joomgallery_maintenance',
+                     '#__joomgallery_nameshields',
+                     '#__joomgallery_orphans',
+                     '#__joomgallery_users',
+                     '#__joomgallery_users_ref',
+                     '#__joomgallery_votes'
+                    );
+
+    // add suffix, if source tables are in the same db with *_old at the end
+    $source_db_suffix = '';
+    if($this->params->get('same_db', 1))
+    {
+      $source_db_suffix = '_old';
+    }
 
     // Delete source tables
     $successful = true;
     foreach($tables as $key => $tablename)
     {
+      // add suffix to tablename
+      $tablename = $tablename . $source_db_suffix;
+
       $query     = $db->getQuery(true);
       $query->setQuery('DROP TABLE IF EXISTS ' . $tablename);
 

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -863,7 +863,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
 
     if(!empty($undeleted))
     {
-      $this->component->setWarning(Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_MANUALLY_DELETE_SOURCE_FOLDERS', $undeleted));
+      $this->component->setWarning(Text::sprintf('COM_JOOMGALLERY_SERVICE_MIGRATION_MANUALLY_DELETE_SOURCE_FOLDERS', implode(', ', $undeleted)));
     }
 
     if(!$successful)

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -1123,7 +1123,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
   {
     $this->component->createConfig();
 
-    if($type == 'pre')
+    if($type == 'pre' && $checks->getSuccess())
     {
       // Get source db info
       list($db, $dbPrefix)            = $this->getDB('source');
@@ -1308,7 +1308,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
       }
     }
 
-    if($type == 'post')
+    if($type == 'post' && $checks->getSuccess())
     {
 
     }

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -816,9 +816,9 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
     // Retrieve a list of source directories involved in migration
     $directories = $this->getSourceDirs();
     $root        = $this->getSourceRootPath();
-    $dir_array   = array( array('Original', 'images/joomgallery/originals/'),
-                          array('Details', 'images/joomgallery/originals/'),
-                          array('Thumbnails', 'images/joomgallery/thumbnails/')
+    $dir_array   = array( array(Text::_('COM_JOOMGALLERY_ORIGINAL'), 'images/joomgallery/originals/'),
+                          array(Text::_('COM_JOOMGALLERY_DETAIL'), 'images/joomgallery/details/'),
+                          array(Text::_('COM_JOOMGALLERY_THUMBNAIL'), 'images/joomgallery/thumbnails/')
                         );
 
     // Delete source directories


### PR DESCRIPTION
This PR adds the functionality of deleting source directories and tables at the end of the migration (step 4).
See issue #359

### How to test this PR
AT step 4 of the migration, the Button `Remove source data` now actually removes the source data.