### PR TITLE
Adjust category paths based on compatibility mode

### DIFF
--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -575,7 +575,7 @@ class CategoryModel extends JoomAdminModel
         if($this->component->getConfig()->get('jg_compatibility_mode', 0))
         {
           $old_path = $old_static_path;
-          $new_path = $table->path;
+          $new_path = $table->static_path;
         }
 
         // Handle folders if parent category was changed

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -426,6 +426,7 @@ class CategoryModel extends JoomAdminModel
           {
             $catMoved = true;
             $old_path = $table->path;
+            $old_static_path = $table->static_path;
           }
 
           // Check if the alias was changed
@@ -434,6 +435,7 @@ class CategoryModel extends JoomAdminModel
             $aliasChanged = true;
             $old_alias    = $table->alias;
             $old_path     = $table->path;
+            $old_static_path = $table->static_path;
           }
 
           // Check if the state was changed
@@ -568,6 +570,14 @@ class CategoryModel extends JoomAdminModel
           return false;
         }
 
+        // Handle paths
+        $new_path = $table->path;
+        if($this->component->getConfig()->get('jg_compatibility_mode', 0))
+        {
+          $old_path = $old_static_path;
+          $new_path = $table->path;
+        }
+
         // Handle folders if parent category was changed
         if(!$isNew && $catMoved)
 			  {
@@ -586,7 +596,7 @@ class CategoryModel extends JoomAdminModel
           $table->setPathWithLocation(false);
 
           // Adjust path of subcategory records
-          if(!$this->fixChildrenPath($table, $old_path, $table->path))
+          if(!$this->fixChildrenPath($table, $old_path, $new_path))
           {
             return false;
           }
@@ -609,7 +619,7 @@ class CategoryModel extends JoomAdminModel
           $table->setPathWithLocation(false);
 
           // Adjust path of subcategory records
-          if(!$this->fixChildrenPath($table, $old_path, $table->path))
+          if(!$this->fixChildrenPath($table, $old_path, $new_path))
           {
             return false;
           }

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -58,6 +58,13 @@ class FileManager implements FileManagerInterface
   protected $no_image = '/images/joomgallery/no-image.png';
 
   /**
+   * Is compatibility mode activated?
+   *
+   * @var bool
+   */
+  protected $compatibility = false;
+
+  /**
    * Storage for paths
    *
    * @var string
@@ -84,6 +91,12 @@ class FileManager implements FileManagerInterface
 
     // Instantiate config service based on provided category
     $this->component->createConfig('com_joomgallery.category', $catid);
+
+    // Set compatibility flag
+    if($this->component->getConfig()->get('jg_compatibility_mode', 0))
+    {
+      $this->compatibility = true;
+    }
 
     // Instantiate filesystem service
     $this->component->createFilesystem($this->component->getConfig()->get('jg_filesystem','local-images'));
@@ -1009,8 +1022,8 @@ class FileManager implements FileManagerInterface
     }
 
     // Create path for messages
-    $this->paths['src'] = '[ROOT]'.\DIRECTORY_SEPARATOR.$this->getCatPath($cat);
-    $this->paths['dest'] = '[ROOT]'.\DIRECTORY_SEPARATOR.$this->getCatPath($cat);
+    $this->paths['src']  = '[ROOT]'.\DIRECTORY_SEPARATOR . $this->getCatPath($cat);
+    $this->paths['dest'] = '[ROOT]'.\DIRECTORY_SEPARATOR . $this->getCatPath($cat);
 
     // Loop through all imagetypes
     $error = false;
@@ -1259,8 +1272,13 @@ class FileManager implements FileManagerInterface
    * 
    * @since   4.0.0
    */
-  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=false, $compatibility=true, $logfile='jerror')
+  public function getCatPath($cat, $type=false, $parent=false, $alias=false, $root=false, $compatibility=null, $logfile='jerror')
   {
+    if(is_null($compatibility))
+    {
+      $compatibility = $this->compatibility;
+    }
+
     // We got a valid category object
     if(\is_object($cat) && \property_exists($cat, 'path'))
     {

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -366,6 +366,13 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     $this->path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, false);
     $this->path = $filesystem->cleanPath($this->path, '/');
 
+    // Create static_path if compatibility mode is activated
+    if($this->component->getConfig()->get('jg_compatibility_mode', 0))
+    {
+      $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, true);
+      $this->static_path = $filesystem->cleanPath($this->path, '/');
+    }
+
     // Support for subform field params
     if(empty($this->params))
     {


### PR DESCRIPTION
This PR fixes the issue reported in #368.

In order to fix that the following mathods were changed:
- CategoryModel::fixChildrenPath()
- CategoryTable::check()
- FileManager::getCatPath()