### PR TITLE
Fix issue when loading multiple items

### DIFF
--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -88,7 +88,7 @@ class CategoryModel extends JoomItemModel
 	 */
 	public function getItem($id = null)
 	{
-		if($this->item === null)
+		if($this->item === null || $this->item->id != $id)
 		{
 			$this->item = false;
 

--- a/site/com_joomgallery/src/Model/ImageModel.php
+++ b/site/com_joomgallery/src/Model/ImageModel.php
@@ -94,7 +94,7 @@ class ImageModel extends JoomItemModel
 	 */
 	public function getItem($id = null)
 	{
-		if($this->item === null)
+		if($this->item === null || $this->item->id != $id)
 		{
 			$this->item = false;
 


### PR DESCRIPTION
This PR solves an issue in a 3rd party extension.

If you try to load multiple images or categories using its ItemModels (ImageModel or CategoryModel) in the fronted, the same item gets loaded multiple times instead of the different ones.

### How to test this PR
Click through the Frontend views. Everything should work as before without errors.