### PR TITLE
Add language filter

### DIFF
--- a/administrator/com_joomgallery/forms/filter_categories.xml
+++ b/administrator/com_joomgallery/forms/filter_categories.xml
@@ -63,7 +63,7 @@
         <field name="language"
                type="language"
                label="JGRID_HEADING_LANGUAGE"
-               onchange="this.form.submit();" />
+               onchange="this.form.submit();" >
             <option value="">JOPTION_SELECT_LANGUAGE</option>
             <option value="*">JALL</option>
         </field>

--- a/administrator/com_joomgallery/forms/filter_categories.xml
+++ b/administrator/com_joomgallery/forms/filter_categories.xml
@@ -60,6 +60,14 @@
                hint="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                onchange="this.form.submit();" />
 
+        <field name="language"
+               type="language"
+               label="JGRID_HEADING_LANGUAGE"
+               onchange="this.form.submit();" />
+            <option value="">JOPTION_SELECT_LANGUAGE</option>
+            <option value="*">JALL</option>
+        </field>
+
         <field
               name="exclude"
               type="jgcategorydropdown"

--- a/administrator/com_joomgallery/forms/filter_images.xml
+++ b/administrator/com_joomgallery/forms/filter_images.xml
@@ -48,6 +48,15 @@
                label="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                hint="COM_JOOMGALLERY_COMMON_OPTION_SELECT_OWNER"
                onchange="this.form.submit();" />
+
+        <field name="language"
+               type="language"
+               label="JGRID_HEADING_LANGUAGE"
+               default=""
+               onchange="this.form.submit();" >
+            <option value="">JOPTION_SELECT_LANGUAGE</option>
+            <option value="*">JALL</option>
+        </field>
     </fields>
 
     <fields name="list"> 
@@ -56,7 +65,7 @@
                label="JGLOBAL_SORT_BY"
                onchange="this.form.submit();"
                default="a.id DESC"
-			         validate="options" >
+               validate="options" >
             <option value="*">JGLOBAL_SORT_BY</option>
             <option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
             <option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>

--- a/administrator/com_joomgallery/forms/filter_tags.xml
+++ b/administrator/com_joomgallery/forms/filter_tags.xml
@@ -25,6 +25,14 @@
                layout="joomla.form.field.list-fancy-select"
                hint="JOPTION_SELECT_ACCESS"
                onchange="this.form.submit();" />
+
+        <field name="language"
+               type="language"
+               label="JGRID_HEADING_LANGUAGE"
+               onchange="this.form.submit();" />
+            <option value="">JOPTION_SELECT_LANGUAGE</option>
+            <option value="*">JALL</option>
+        </field>
     </fields>
 
     <fields name="list">

--- a/administrator/com_joomgallery/forms/filter_tags.xml
+++ b/administrator/com_joomgallery/forms/filter_tags.xml
@@ -29,7 +29,7 @@
         <field name="language"
                type="language"
                label="JGRID_HEADING_LANGUAGE"
-               onchange="this.form.submit();" />
+               onchange="this.form.submit();" >
             <option value="">JOPTION_SELECT_LANGUAGE</option>
             <option value="*">JALL</option>
         </field>

--- a/administrator/com_joomgallery/src/Model/CategoriesModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoriesModel.php
@@ -120,7 +120,7 @@ class CategoriesModel extends JoomListModel
 		$this->setState('filter.published', $published);
     $level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', '*');
 		$this->setState('filter.level', $level);
-    $language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '*');
+    $language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
 		$this->setState('filter.language', $language);
     $showself = $this->getUserStateFromRequest($this->context . '.filter.showself', 'filter_showself', '1');
     $this->setState('filter.showself', $showself);

--- a/administrator/com_joomgallery/src/Model/ImagesModel.php
+++ b/administrator/com_joomgallery/src/Model/ImagesModel.php
@@ -119,7 +119,7 @@ class ImagesModel extends JoomListModel
 		$this->setState('filter.search', $search);
 		$published = $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '*');
 		$this->setState('filter.published', $published);
-		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '*');
+		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
 		$this->setState('filter.language', $language);
     $showunapproved = $this->getUserStateFromRequest($this->context . '.filter.showunapproved', 'filter_showunapproved', '1');
     $this->setState('filter.showunapproved', $showunapproved);


### PR DESCRIPTION
Possible fix for https://github.com/JoomGalleryfriends/JG4-dev/issues/382

This PR adds the missing language filters for images, categories. tags