### PR TITLE
Warning with unicodeslugs activated

### DIFF
--- a/administrator/com_joomgallery/includes/latinbased.php
+++ b/administrator/com_joomgallery/includes/latinbased.php
@@ -1,0 +1,57 @@
+<?php
+/**
+******************************************************************************************
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2025  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+*****************************************************************************************/
+
+// No direct access
+defined('_JEXEC') or die;
+
+/**
+ * Array containing official Joomla languages
+ * with a latin based writing system
+ *
+ * @package JoomGallery
+ * @since   4.0.0
+ */
+$latin_based_languages = [
+  'af-ZA', // Afrikaans
+  'ca-ES', // Catalan
+  'hr-HR', // Croatian
+  'cs-CZ', // Czech
+  'da-DK', // Danish
+  'nl-NL', // Dutch
+  'en-AU', // English, Australia
+  'en-CA', // English, Canada
+  'en-NZ', // English, New Zealand
+  'en-US', // English, USA
+  'et-EE', // Estonian
+  'fi-FI', // Finnish
+  'nl-BE', // Flemish
+  'fr-FR', // French
+  'fr-CA', // French, Canada
+  'de-DE', // German
+  'de-AT', // German, Austria
+  'de-LI', // German, Liechtenstein
+  'de-LU', // German, Luxembourg
+  'de-CH', // German, Switzerland
+  'hu-HU', // Hungarian
+  'it-IT', // Italian
+  'lv-LV', // Latvian
+  'lt-LT', // Lithuanian
+  'nb-NO', // Norwegian Bokmål
+  'pl-PL', // Polish
+  'pt-BR', // Portuguese, Brazil
+  'pt-PT', // Portuguese, Portugal
+  'ro-RO', // Romanian
+  'sr-YU', // Serbian, Latin
+  'sk-SK', // Slovak
+  'sl-SI', // Slovenian
+  'es-ES', // Spanish
+  'sv-SE', // Swedish
+  'tr-TR', // Turkish
+  'cy-GB'  // Welsh
+];

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -259,6 +259,7 @@ COM_JOOMGALLERY_CONTROL_LIST_EXTENSION_LABEL="Want to list your JoomGallery exte
 
 ;Messages
 COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION="Attention!<br />----------------<br />This version of JoomGallery is still under development. Do not use this version on a live website. It is intended for testing purposes only..."
+COM_JOOMGALLERY_ERROR_UNICODESLUGS="Attention!<br />----------------<br />You have activated the option <strong>Unicode Aliases</strong> in the Joomla! Global Configuration.<br>This will lead to errors with the image paths as JoomGallery stores images based on its category aliases. Please deactivate <strong>Unicode Aliases</strong> if not really needed or make sure there are no non-latin/special characters in your image or category aliases especially during creation!"
 COM_JOOMGALLERY_ERROR_NOT_YET_AVAILABLE="The view or feature you are looking for is not yet available...<br /><small>Add 'preview=1' to your query parameters (URL) to access this anyway. But be aware that this may not work properly as it is not yet fully developed!</small>"
 COM_JOOMGALLERY_ERROR_LOAD_GLOB_CONFIG="Error loading Global Configuration.<br />Make sure the global configuration set with ID=1 is available in DB table #__joomgallery_configs."
 COM_JOOMGALLERY_ERROR_CONFIG_INVALID_CONTEXT="Error deriving settings from configurations. Provided context may be wrong. Context: %s"

--- a/administrator/com_joomgallery/src/View/JoomGalleryView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryView.php
@@ -100,6 +100,12 @@ class JoomGalleryView extends BaseHtmlView
       // We are dealing with a development version (alpha, beta, rc)
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION'), 'warning');
     }
+
+    if($this->app->get('unicodeslugs', false))
+    {
+      // The option unicodeslugs is activated.
+      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNICODESLUGS'), 'warning');
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds a warning to all JoomGallery backend views if `Unicode Aliases` in the Joomla! Global Configuration is activated.

See Issue #386 .